### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/168/913/421168913.geojson
+++ b/data/421/168/913/421168913.geojson
@@ -590,6 +590,9 @@
     },
     "wof:country":"LA",
     "wof:created":1459008786,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3ff69d1d13c5b5b2009ad6162bd56e0f",
     "wof:hierarchy":[
         {
@@ -601,7 +604,7 @@
         }
     ],
     "wof:id":421168913,
-    "wof:lastmodified":1566593353,
+    "wof:lastmodified":1582318654,
     "wof:name":"Vientiane",
     "wof:parent_id":1092027747,
     "wof:placetype":"locality",

--- a/data/421/173/147/421173147.geojson
+++ b/data/421/173/147/421173147.geojson
@@ -152,6 +152,9 @@
     },
     "wof:country":"LA",
     "wof:created":1459008972,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"212298ad63fc0b929df73d11edcbbc70",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":421173147,
-    "wof:lastmodified":1566593355,
+    "wof:lastmodified":1582318654,
     "wof:name":"Xiangkhoang",
     "wof:parent_id":1092027229,
     "wof:placetype":"locality",

--- a/data/856/322/41/85632241.geojson
+++ b/data/856/322/41/85632241.geojson
@@ -1019,6 +1019,11 @@
     },
     "wof:country":"LA",
     "wof:country_alpha3":"LAO",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"3841799197d45646dea322790a41dd03",
     "wof:hierarchy":[
         {
@@ -1033,7 +1038,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592623,
+    "wof:lastmodified":1582318636,
     "wof:name":"Laos",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/734/09/85673409.geojson
+++ b/data/856/734/09/85673409.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Bokeo Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e55e73cbb4a2ae708058eea3e1ac5ae8",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592630,
+    "wof:lastmodified":1582318639,
     "wof:name":"Bokeo",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/13/85673413.geojson
+++ b/data/856/734/13/85673413.geojson
@@ -288,6 +288,9 @@
         "wd:id":"Q948691"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b31643f064481fec10e57b7e0beb8766",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592633,
+    "wof:lastmodified":1582318641,
     "wof:name":"Louang Namtha",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/17/85673417.geojson
+++ b/data/856/734/17/85673417.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Sainyabuli Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cb03612b90b92940a71674260a8dafa7",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592630,
+    "wof:lastmodified":1582318639,
     "wof:name":"Xaignabouri",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/23/85673423.geojson
+++ b/data/856/734/23/85673423.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Champasak Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77ad848821fe68324fa6d6f00801efc7",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592632,
+    "wof:lastmodified":1582318640,
     "wof:name":"Champasak",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/27/85673427.geojson
+++ b/data/856/734/27/85673427.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Salavan Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"774f9f51c145d94d18c8080ec1e8d5db",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592628,
+    "wof:lastmodified":1582318638,
     "wof:name":"Saravan",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/29/85673429.geojson
+++ b/data/856/734/29/85673429.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Savannakhet Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64e5984aedadee6a01397a01bb940752",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592629,
+    "wof:lastmodified":1582318639,
     "wof:name":"Savannakh\u00e9t",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/33/85673433.geojson
+++ b/data/856/734/33/85673433.geojson
@@ -217,6 +217,9 @@
         "wk:page":"Vientiane Prefecture"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d2e6fdcdea4ea3b2087ae732365a18c",
     "wof:hierarchy":[
         {
@@ -232,7 +235,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592628,
+    "wof:lastmodified":1582318638,
     "wof:name":"Vientiane (prefecture)",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/37/85673437.geojson
+++ b/data/856/734/37/85673437.geojson
@@ -205,6 +205,9 @@
         "wk:page":"Vientiane Prefecture"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1275d591b9eb4b5c59c0d3e1ae088297",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592631,
+    "wof:lastmodified":1582318640,
     "wof:name":"Vientiane",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/41/85673441.geojson
+++ b/data/856/734/41/85673441.geojson
@@ -264,6 +264,9 @@
         "wk:page":"Xiangkhouang Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf44c7867a043725332e65ed082fd147",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592632,
+    "wof:lastmodified":1582318640,
     "wof:name":"Xiangkhoang",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/47/85673447.geojson
+++ b/data/856/734/47/85673447.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Houaphanh Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4f14973be6ea1fbd5fd427932ea1c21",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592633,
+    "wof:lastmodified":1582318640,
     "wof:name":"Houaphan",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/51/85673451.geojson
+++ b/data/856/734/51/85673451.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Luang Prabang Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a09fa01ff731e1a01967c2967101a77",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592627,
+    "wof:lastmodified":1582318638,
     "wof:name":"Luangphrabang",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/53/85673453.geojson
+++ b/data/856/734/53/85673453.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Oudomxay Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23480211f11e73680e59621aacda3309",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592631,
+    "wof:lastmodified":1582318640,
     "wof:name":"Oud\u00f4mxai",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/59/85673459.geojson
+++ b/data/856/734/59/85673459.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Phongsaly Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9302b859d6e7d11e2cb7cc3b61aebd77",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592626,
+    "wof:lastmodified":1582318637,
     "wof:name":"Ph\u00f4ngsali",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/63/85673463.geojson
+++ b/data/856/734/63/85673463.geojson
@@ -268,6 +268,9 @@
         "wk:page":"Bolikhamsai Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c7f851150e7d4f6d9ef199ace949b8f",
     "wof:hierarchy":[
         {
@@ -283,7 +286,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592631,
+    "wof:lastmodified":1582318640,
     "wof:name":"Borikhamxai",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/67/85673467.geojson
+++ b/data/856/734/67/85673467.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Khammouane Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32e3ab14964f6cf74837ae968cd78cda",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592627,
+    "wof:lastmodified":1582318638,
     "wof:name":"Khammouan",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/69/85673469.geojson
+++ b/data/856/734/69/85673469.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Attapeu Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc26fe5bd9d72b403e0ae392fa0bc71b",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592626,
+    "wof:lastmodified":1582318638,
     "wof:name":"Attapeu",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/73/85673473.geojson
+++ b/data/856/734/73/85673473.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Sekong Province"
     },
     "wof:country":"LA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"799978b081bdb1c25366ff09d708424b",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1566592629,
+    "wof:lastmodified":1582318639,
     "wof:name":"X\u00e9kong",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/890/433/789/890433789.geojson
+++ b/data/890/433/789/890433789.geojson
@@ -201,6 +201,9 @@
     },
     "wof:country":"LA",
     "wof:created":1469051995,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3729b1332f56e88c3660858ce09bcc00",
     "wof:hierarchy":[
         {
@@ -212,7 +215,7 @@
         }
     ],
     "wof:id":890433789,
-    "wof:lastmodified":1566593359,
+    "wof:lastmodified":1582318654,
     "wof:name":"Ban Houayxay",
     "wof:parent_id":1092031167,
     "wof:placetype":"locality",

--- a/data/890/443/901/890443901.geojson
+++ b/data/890/443/901/890443901.geojson
@@ -190,6 +190,9 @@
     },
     "wof:country":"LA",
     "wof:created":1469052442,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8080a75865e66ef753cafc7c75571d90",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
         }
     ],
     "wof:id":890443901,
-    "wof:lastmodified":1566593358,
+    "wof:lastmodified":1582318654,
     "wof:name":"Champasak",
     "wof:parent_id":1092027043,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.