### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/542/635/102542635.geojson
+++ b/data/102/542/635/102542635.geojson
@@ -13,6 +13,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":13.0,
+    "name:ceb_x_preferred":[
+        "Sam Neua Airport"
+    ],
     "name:eng_x_preferred":[
         "Sam Neua"
     ],
@@ -23,8 +26,14 @@
     "name:fra_x_preferred":[
         "Sam Neua"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ca\u30bd\u30f3\u7a7a\u6e2f"
+    ],
     "name:pol_x_preferred":[
         "Port lotniczy Sam Neua"
+    ],
+    "name:swe_x_preferred":[
+        "Sam Neua Airport"
     ],
     "oa:elevation_ft":"3281",
     "oa:type":"medium_airport",
@@ -57,7 +66,7 @@
         }
     ],
     "wof:id":102542635,
-    "wof:lastmodified":1631745170,
+    "wof:lastmodified":1690938488,
     "wof:name":"Sam Neua Airport",
     "wof:parent_id":85673447,
     "wof:placetype":"campus",

--- a/data/112/593/980/3/1125939803.geojson
+++ b/data/112/593/980/3/1125939803.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Ban Houayxay"
+    ],
+    "name:ceb_x_preferred":[
+        "H\u016bais\u0101i"
+    ],
     "name:ces_x_preferred":[
         "Huay Xai"
     ],
@@ -30,6 +36,9 @@
     ],
     "name:eng_x_preferred":[
         "Ban Houayxay"
+    ],
+    "name:eng_x_variant":[
+        "H\u016bais\u0101i"
     ],
     "name:epo_x_preferred":[
         "Ban Huajsai"
@@ -40,6 +49,9 @@
     "name:fra_x_preferred":[
         "Houei Sai"
     ],
+    "name:fra_x_variant":[
+        "Houayxay"
+    ],
     "name:ita_x_preferred":[
         "Ban Houayxay"
     ],
@@ -48,6 +60,12 @@
     ],
     "name:kat_x_preferred":[
         "\u10f0\u10e3\u10d0\u10d8\u10e1\u10d0\u10d8"
+    ],
+    "name:khm_x_preferred":[
+        "\u17a0\u17bd\u1799\u179f\u17b6\u1799"
+    ],
+    "name:kor_x_preferred":[
+        "\ubc18\ud6c4\uc548\uc0ac\uc774"
     ],
     "name:lao_x_preferred":[
         "\u0eab\u0ec9\u0ea7\u0e8d\u0e8a\u0eb2\u0e8d"
@@ -64,8 +82,17 @@
     "name:rus_x_variant":[
         "\u0425\u0443\u044d\u0439\u0441\u0430\u0439"
     ],
+    "name:spa_x_preferred":[
+        "H\u016bais\u0101i"
+    ],
+    "name:swe_x_preferred":[
+        "Ban Houayxay"
+    ],
     "name:tha_x_preferred":[
         "\u0e2b\u0e49\u0e27\u0e22\u0e17\u0e23\u0e32\u0e22"
+    ],
+    "name:tur_x_preferred":[
+        "Houayxay"
     ],
     "name:urd_x_preferred":[
         "\u0628\u0627\u0646 \u06c1\u0648\u0648\u0627\u06d2 \u0633\u0627\u0626\u06d2"
@@ -75,6 +102,9 @@
     ],
     "name:war_x_preferred":[
         "Ban Houayxay"
+    ],
+    "name:war_x_variant":[
+        "H\u016bais\u0101i"
     ],
     "name:zho_x_preferred":[
         "\u6703\u6652"
@@ -118,7 +148,7 @@
         }
     ],
     "wof:id":1125939803,
-    "wof:lastmodified":1566593359,
+    "wof:lastmodified":1690938507,
     "wof:name":"Ban Houakhoua",
     "wof:parent_id":1092031167,
     "wof:placetype":"locality",

--- a/data/421/168/913/421168913.geojson
+++ b/data/421/168/913/421168913.geojson
@@ -31,6 +31,18 @@
     "name:ara_x_preferred":[
         "\u0641\u064a\u064a\u0646\u062a\u064a\u0627\u0646"
     ],
+    "name:arg_x_preferred":[
+        "Vientiane"
+    ],
+    "name:ary_x_preferred":[
+        "\u06a4\u064a\u064a\u0646\u062a\u0627\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0641\u064a\u064a\u0646\u062a\u064a\u0627\u0646"
+    ],
+    "name:asm_x_preferred":[
+        "\u09ad\u09bf\u09af\u09bc\u09c7\u09a8\u099f\u09bf\u09af\u09bc\u09c7\u09a8"
+    ],
     "name:ast_x_preferred":[
         "Vienti\u00e1n"
     ],
@@ -40,8 +52,14 @@
     "name:bak_x_preferred":[
         "\u0412\u044c\u0435\u043d\u0442\u044c\u044f\u043d"
     ],
+    "name:ban_x_preferred":[
+        "Vientiane"
+    ],
     "name:bcl_x_preferred":[
         "Vientiane"
+    ],
+    "name:bcl_x_variant":[
+        "Biyentiyan"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0412\u0435\u043d\u0446\u044c\u044f\u043d"
@@ -54,6 +72,9 @@
     ],
     "name:bjn_x_preferred":[
         "Wiangcan"
+    ],
+    "name:blk_x_preferred":[
+        "\u101d\u1031\u1004\u103a\uaa7b\u1017\u102e\u101a\u1014\u103a\u1011\u103b\u1014\u103a\u1038"
     ],
     "name:bod_x_preferred":[
         "\u0f5d\u0f72\u0f53\u0f0b\u0f46\u0f72\u0f60\u0f44\u0f0b"
@@ -78,6 +99,9 @@
     ],
     "name:ceb_x_preferred":[
         "Vientiane"
+    ],
+    "name:ceb_x_variant":[
+        "Biyentiyan"
     ],
     "name:ces_x_preferred":[
         "Vientiane"
@@ -133,6 +157,9 @@
     "name:fra_x_preferred":[
         "Vientiane"
     ],
+    "name:frp_x_preferred":[
+        "Vientiane"
+    ],
     "name:frr_x_preferred":[
         "Vientiane"
     ],
@@ -159,6 +186,9 @@
     ],
     "name:hat_x_preferred":[
         "Vyanty\u00e0n"
+    ],
+    "name:hau_x_preferred":[
+        "Vientiane"
     ],
     "name:heb_x_preferred":[
         "\u05d5\u05d9\u05d0\u05e0\u05d8\u05d9\u05d0\u05df"
@@ -193,6 +223,9 @@
     "name:ilo_x_preferred":[
         "Vientiane"
     ],
+    "name:ilo_x_variant":[
+        "Bientian"
+    ],
     "name:ind_x_preferred":[
         "Vientiane"
     ],
@@ -219,6 +252,9 @@
     ],
     "name:kaz_x_preferred":[
         "\u0412\u044c\u0435\u043d\u0442\u044c\u044f\u043d"
+    ],
+    "name:khm_x_preferred":[
+        "\u179c\u17b6\u17c6\u1784\u1785\u1793\u17d2\u1791\u1793\u17cd"
     ],
     "name:kir_x_preferred":[
         "\u0412\u044c\u0435\u043d\u0442\u044c\u044f\u043d"
@@ -265,10 +301,19 @@
     "name:mar_x_preferred":[
         "\u0935\u094d\u0939\u093f\u0906\u0902\u0924\u093f\u092f\u093e\u0928"
     ],
+    "name:mdf_x_preferred":[
+        "\u0412\u0438\u0435\u043d\u0442\u044c\u044f\u043d"
+    ],
+    "name:min_x_preferred":[
+        "Vientiane"
+    ],
     "name:mkd_x_preferred":[
         "\u0412\u0438\u0435\u043d\u0442\u0438\u0458\u0430\u043d"
     ],
     "name:mlg_x_preferred":[
+        "Vientiane"
+    ],
+    "name:mlt_x_preferred":[
         "Vientiane"
     ],
     "name:mon_x_preferred":[
@@ -283,11 +328,20 @@
     "name:mya_x_preferred":[
         "\u1017\u102e\u101a\u1004\u103a\u1000\u103b\u1014\u103a\u1038\u1019\u103c\u102d\u102f\u1037"
     ],
+    "name:mzn_x_preferred":[
+        "\u0648\u06cc\u0646\u062a\u06cc\u0627\u0646"
+    ],
     "name:nah_x_preferred":[
         "Vianchan"
     ],
     "name:nan_x_preferred":[
         "Vieng Chan"
+    ],
+    "name:nan_x_variant":[
+        "Vientiane"
+    ],
+    "name:nav_x_preferred":[
+        "Tsin\u0142\u00e1n\u00ed Bin\u00e1\u02bc\u00e1t\u0142\u02bcinii"
     ],
     "name:nep_x_preferred":[
         "\u092d\u093f\u092f\u0928\u091f\u093f\u092f\u093e\u0928"
@@ -346,6 +400,9 @@
     "name:rus_x_preferred":[
         "\u0412\u044c\u0435\u043d\u0442\u044c\u044f\u043d"
     ],
+    "name:sat_x_preferred":[
+        "\u1c75\u1c77\u1c64\u1c6d\u1c6e\u1c71\u1c5b\u1c64\u1c6d\u1c6e\u1c71"
+    ],
     "name:scn_x_preferred":[
         "Vientiane"
     ],
@@ -361,6 +418,9 @@
     "name:slv_x_preferred":[
         "Vientiane"
     ],
+    "name:smn_x_preferred":[
+        "Vientiane"
+    ],
     "name:sna_x_preferred":[
         "Vientiane"
     ],
@@ -373,6 +433,9 @@
     "name:sqi_x_preferred":[
         "Vientiane"
     ],
+    "name:srd_x_preferred":[
+        "Vientiane"
+    ],
     "name:srp_x_preferred":[
         "\u0412\u0438\u0458\u0435\u043d\u0442\u0438\u0458\u0430\u043d"
     ],
@@ -381,6 +444,9 @@
     ],
     "name:swe_x_preferred":[
         "Vientiane"
+    ],
+    "name:szl_x_preferred":[
+        "Wjentjan"
     ],
     "name:tam_x_preferred":[
         "\u0bb5\u0bbf\u0baf\u0b9e\u0bcd\u0b9a\u0bbe\u0ba9\u0bcd"
@@ -396,6 +462,9 @@
     ],
     "name:tgl_x_preferred":[
         "Vientiane"
+    ],
+    "name:tgl_x_variant":[
+        "Biyentiyan"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e27\u0e35\u0e22\u0e07\u0e08\u0e31\u0e19\u0e17\u0e19\u0e4c"
@@ -424,6 +493,9 @@
     "name:uzb_x_preferred":[
         "Ventyan"
     ],
+    "name:vec_x_preferred":[
+        "Vientiane"
+    ],
     "name:vep_x_preferred":[
         "Vjentjan"
     ],
@@ -438,6 +510,9 @@
     ],
     "name:war_x_preferred":[
         "Vientiane"
+    ],
+    "name:war_x_variant":[
+        "Biyentiyan"
     ],
     "name:wuu_x_preferred":[
         "\u4e07\u8c61"
@@ -609,7 +684,7 @@
         }
     ],
     "wof:id":421168913,
-    "wof:lastmodified":1636495634,
+    "wof:lastmodified":1690938502,
     "wof:name":"Vientiane",
     "wof:parent_id":1092027747,
     "wof:placetype":"locality",

--- a/data/421/173/145/421173145.geojson
+++ b/data/421/173/145/421173145.geojson
@@ -20,11 +20,17 @@
     "name:ara_x_preferred":[
         "\u0644\u0648\u0627\u0646\u063a \u0646\u0627\u0645\u062b\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0648\u0627\u0646\u062c \u0646\u0627\u0645\u062b\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09c1\u09af\u09bc\u09be\u0982 \u09a8\u09be\u09ae\u09a5\u09be"
     ],
     "name:ceb_x_preferred":[
         "Louang Namtha"
+    ],
+    "name:ceb_x_variant":[
+        "L\u016bang Namth\u0101"
     ],
     "name:ces_x_preferred":[
         "Luang Namtha"
@@ -41,6 +47,9 @@
     "name:eng_x_preferred":[
         "Luang Namtha"
     ],
+    "name:eng_x_variant":[
+        "L\u016bang Namth\u0101"
+    ],
     "name:epo_x_preferred":[
         "Luang Namtha"
     ],
@@ -52,6 +61,9 @@
     ],
     "name:fra_x_preferred":[
         "Louang Namtha"
+    ],
+    "name:fra_x_variant":[
+        "Louang-Namtha"
     ],
     "name:guj_x_preferred":[
         "\u0ab2\u0ac1\u0a82\u0a86\u0a82\u0a97 \u0aa8\u0aae\u0aa5\u0abe"
@@ -79,6 +91,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10da\u10e3\u10d0\u10dc\u10d2\u10dc\u10d0\u10db\u10e2\u10f0\u10d0"
+    ],
+    "name:khm_x_preferred":[
+        "\u17a0\u17d2\u179b\u17bd\u1784\u178e\u17b6\u17c6\u1790\u17b6"
     ],
     "name:kor_x_preferred":[
         "\ub8e8\uc559 \ub0a8\uc0ac"
@@ -122,8 +137,14 @@
     "name:spa_x_preferred":[
         "Luang Namtha"
     ],
+    "name:spa_x_variant":[
+        "L\u016bang Namth\u0101"
+    ],
     "name:swe_x_preferred":[
         "Louang Namtha"
+    ],
+    "name:swe_x_variant":[
+        "L\u016bang Namth\u0101"
     ],
     "name:tam_x_preferred":[
         "\u0bb2\u0bc1\u0b86\u0b99\u0bcd \u0ba8\u0bae\u0bcd\u0ba4\u0bbe"
@@ -151,6 +172,9 @@
     ],
     "name:war_x_preferred":[
         "Luang Nam Tha"
+    ],
+    "name:war_x_variant":[
+        "L\u016bang Namth\u0101"
     ],
     "name:zho_x_preferred":[
         "\u7405\u5357\u5854"
@@ -294,7 +318,7 @@
         }
     ],
     "wof:id":421173145,
-    "wof:lastmodified":1636495634,
+    "wof:lastmodified":1690938503,
     "wof:name":"Louang Namtha",
     "wof:parent_id":1092027341,
     "wof:placetype":"locality",

--- a/data/421/174/031/421174031.geojson
+++ b/data/421/174/031/421174031.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0622\u062a\u0627\u0628\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u062a\u0627\u0628\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Attapeu"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0442\u0430\u043f\u044b"
     ],
@@ -34,6 +40,9 @@
     ],
     "name:cat_x_preferred":[
         "Attapeu"
+    ],
+    "name:ceb_x_preferred":[
+        "Attap\u01b0\u0304"
     ],
     "name:dan_x_preferred":[
         "Attapeu"
@@ -47,6 +56,9 @@
     "name:eng_x_preferred":[
         "Attapeu"
     ],
+    "name:eng_x_variant":[
+        "Attap\u01b0\u0304"
+    ],
     "name:epo_x_preferred":[
         "Attapeu"
     ],
@@ -59,8 +71,14 @@
     "name:fra_x_preferred":[
         "Attapeu"
     ],
+    "name:fra_x_variant":[
+        "Attapu"
+    ],
     "name:guj_x_preferred":[
         "\u0a85\u0a9f\u0abe\u0aaa\u0ac1"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d8\u05d5\u05e4\u05d5"
     ],
     "name:hin_x_preferred":[
         "\u0905\u091f\u094d\u0920\u093e\u092a\u0947\u0909"
@@ -85,6 +103,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10d0\u10e2\u10d0\u10de\u10d8"
+    ],
+    "name:khm_x_preferred":[
+        "\u17a2\u17b6\u1785\u1798\u17cd\u1780\u17d2\u179a\u1796\u17be"
     ],
     "name:kor_x_preferred":[
         "\uc557\ud398\uc720"
@@ -122,8 +143,14 @@
     "name:spa_x_preferred":[
         "Attapeu"
     ],
+    "name:spa_x_variant":[
+        "Attap\u01b0\u0304"
+    ],
     "name:swe_x_preferred":[
         "Attapeu"
+    ],
+    "name:swe_x_variant":[
+        "Attap\u01b0\u0304"
     ],
     "name:tam_x_preferred":[
         "\u0b85\u0b9f\u0bbe\u0baa\u0bc2"
@@ -140,6 +167,9 @@
     "name:ukr_x_preferred":[
         "\u0410\u0442\u0442\u0430\u043f\u0456"
     ],
+    "name:ukr_x_variant":[
+        "\u0410\u0442\u0442\u0430\u043f\u0438"
+    ],
     "name:und_x_variant":[
         "Muong Attopeu"
     ],
@@ -151,6 +181,9 @@
     ],
     "name:war_x_preferred":[
         "Attapeu"
+    ],
+    "name:war_x_variant":[
+        "Attap\u01b0\u0304"
     ],
     "name:zho_x_preferred":[
         "\u963f\u901f\u5761"
@@ -208,7 +241,7 @@
         }
     ],
     "wof:id":421174031,
-    "wof:lastmodified":1636495634,
+    "wof:lastmodified":1690938502,
     "wof:name":"Attapu",
     "wof:parent_id":1092028773,
     "wof:placetype":"locality",

--- a/data/421/187/451/421187451.geojson
+++ b/data/421/187/451/421187451.geojson
@@ -44,6 +44,9 @@
     "name:lao_x_preferred":[
         "\u0ec0\u0ea1\u0eb7\u0ead\u0e87\u0eaa\u0eb5\u0e87"
     ],
+    "name:lao_x_variant":[
+        "\u0ec0\u0ea1\u0eb7\u0ead\u0e87\u0eaa\u0eb4\u0e87"
+    ],
     "name:spa_x_preferred":[
         "Sing"
     ],
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421187451,
-    "wof:lastmodified":1566593355,
+    "wof:lastmodified":1690938502,
     "wof:name":"Muang Sing",
     "wof:parent_id":1092030925,
     "wof:placetype":"locality",

--- a/data/421/195/609/421195609.geojson
+++ b/data/421/195/609/421195609.geojson
@@ -20,6 +20,15 @@
     "name:ara_x_preferred":[
         "\u0641\u0627\u0646\u063a \u0641\u064a\u0646\u063a"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0627\u0646\u062c \u0641\u064a\u0646\u062c"
+    ],
+    "name:bul_x_preferred":[
+        "\u0412\u0430\u043d\u0433\u0432\u0438\u0430\u043d\u0433"
+    ],
+    "name:ceb_x_preferred":[
+        "Vangviang"
+    ],
     "name:deu_x_preferred":[
         "Vang Vieng"
     ],
@@ -53,8 +62,17 @@
     "name:kor_x_preferred":[
         "\ubc29\ube44\uc5e5"
     ],
+    "name:krj_x_preferred":[
+        "Vangv\u012bang"
+    ],
     "name:lao_x_preferred":[
         "\u0ea7\u0eb1\u0e87\u0ea7\u0ebd\u0e87"
+    ],
+    "name:ltz_x_preferred":[
+        "Vang Vieng"
+    ],
+    "name:msa_x_preferred":[
+        "Vang Vieng"
     ],
     "name:nld_x_preferred":[
         "Vang Vieng"
@@ -143,7 +161,7 @@
         }
     ],
     "wof:id":421195609,
-    "wof:lastmodified":1566593353,
+    "wof:lastmodified":1690938502,
     "wof:name":"Vangviang",
     "wof:parent_id":1092029367,
     "wof:placetype":"locality",

--- a/data/421/195/647/421195647.geojson
+++ b/data/421/195/647/421195647.geojson
@@ -38,6 +38,9 @@
     "name:nld_x_preferred":[
         "Hongsa"
     ],
+    "name:pol_x_preferred":[
+        "Hongsa"
+    ],
     "name:spa_x_preferred":[
         "Hongsa"
     ],
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421195647,
-    "wof:lastmodified":1566593353,
+    "wof:lastmodified":1690938502,
     "wof:name":"Muang Hongsa",
     "wof:parent_id":1092027837,
     "wof:placetype":"locality",

--- a/data/421/196/137/421196137.geojson
+++ b/data/421/196/137/421196137.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0641\u0648\u0646\u0633\u0627\u0641\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0648\u0646\u0633\u0627\u0641\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Phonsavan"
+    ],
     "name:ben_x_preferred":[
         "\u09ab\u09cb\u0982\u09b8\u09be\u09ad\u09be\u09a8"
     ],
@@ -31,6 +37,9 @@
     ],
     "name:ceb_x_preferred":[
         "Phonsavan"
+    ],
+    "name:ceb_x_variant":[
+        "Ph\u014dnsavan"
     ],
     "name:ces_x_preferred":[
         "Phonsavan"
@@ -47,6 +56,9 @@
     "name:eng_x_preferred":[
         "Phonsavan"
     ],
+    "name:eng_x_variant":[
+        "Ph\u014dnsavan"
+    ],
     "name:epo_x_preferred":[
         "Phonsavan"
     ],
@@ -58,6 +70,9 @@
     ],
     "name:fra_x_preferred":[
         "Phonsavan"
+    ],
+    "name:fra_x_variant":[
+        "Ph\u00f4nsavan"
     ],
     "name:fur_x_preferred":[
         "Phonsavan"
@@ -80,8 +95,14 @@
     "name:kan_x_preferred":[
         "\u0cab\u0ccb\u0ca8\u0ccd\u0cb8\u0cbe\u0cb5\u0ca8\u0ccd"
     ],
+    "name:khm_x_preferred":[
+        "\u1796\u17c4\u1793\u179f\u17bd\u1782\u17cc"
+    ],
     "name:kor_x_preferred":[
         "\ud3f0\uc0ac\ubc18"
+    ],
+    "name:krj_x_preferred":[
+        "Ph\u014dnsavan"
     ],
     "name:lao_x_preferred":[
         "\u0ec2\u0e9e\u0e99\u0eaa\u0eb0\u0eab\u0ea7\u0eb1\u0e99"
@@ -119,6 +140,9 @@
     "name:spa_x_preferred":[
         "Phonsavan"
     ],
+    "name:spa_x_variant":[
+        "Ph\u014dnsavan"
+    ],
     "name:swe_x_preferred":[
         "Phonsavan"
     ],
@@ -137,6 +161,9 @@
     "name:ukr_x_preferred":[
         "\u041f\u0445\u043e\u043d\u0441\u0430\u0432\u0430\u043d\u0430"
     ],
+    "name:ukr_x_variant":[
+        "\u041f\u0445\u043e\u043d\u0441\u0430\u0432\u0430\u043d"
+    ],
     "name:und_x_variant":[
         "Phong Savan"
     ],
@@ -151,6 +178,9 @@
     ],
     "name:war_x_preferred":[
         "Phonsavan"
+    ],
+    "name:war_x_variant":[
+        "Ph\u014dnsavan"
     ],
     "name:zho_x_preferred":[
         "\u8c50\u6c99\u7063"
@@ -201,7 +231,7 @@
         }
     ],
     "wof:id":421196137,
-    "wof:lastmodified":1566593356,
+    "wof:lastmodified":1690938503,
     "wof:name":"Muang Ph\u00f4nsavan",
     "wof:parent_id":1092028523,
     "wof:placetype":"locality",

--- a/data/421/201/947/421201947.geojson
+++ b/data/421/201/947/421201947.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0645 \u0646\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0645 \u0646\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Sam N\u01b0\u0304a"
+    ],
     "name:bar_x_preferred":[
         "Sam Neua"
     ],
@@ -29,8 +35,14 @@
     "name:ceb_x_preferred":[
         "Xam Nua"
     ],
+    "name:ceb_x_variant":[
+        "Sam N\u01b0\u0304a"
+    ],
     "name:dan_x_preferred":[
         "Xam Neua"
+    ],
+    "name:dan_x_variant":[
+        "Sam N\u01b0\u0304a"
     ],
     "name:deu_x_preferred":[
         "Xam Neua"
@@ -47,11 +59,20 @@
     "name:fin_x_preferred":[
         "Xam Neua"
     ],
+    "name:fin_x_variant":[
+        "Sam N\u01b0\u0304a"
+    ],
     "name:fra_x_preferred":[
         "Sam Neua"
     ],
+    "name:fra_x_variant":[
+        "Xam-Nua"
+    ],
     "name:guj_x_preferred":[
         "\u0a9d\u0ac7\u0aae \u0aa8\u0ac1\u0a86"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05dd \u05e0\u05d5\u05d0\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u091c\u093c\u093e\u092e \u0928\u0909\u0906"
@@ -62,8 +83,14 @@
     "name:ind_x_preferred":[
         "Xam Neua"
     ],
+    "name:ind_x_variant":[
+        "Sam N\u01b0\u0304a"
+    ],
     "name:ita_x_preferred":[
         "Xam Neua"
+    ],
+    "name:ita_x_variant":[
+        "Sam N\u01b0\u0304a"
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30e0\u30cc\u30a2"
@@ -71,8 +98,17 @@
     "name:kan_x_preferred":[
         "\u0c9d\u0ccd\u0caf\u0cbe\u0cae\u0ccd \u0ca8\u0ccd\u0caf\u0cc2\u0cb5\u0cbe"
     ],
+    "name:khm_x_preferred":[
+        "\u179f\u17b6\u17c6\u17a0\u17d2\u1793\u17bf"
+    ],
     "name:kor_x_preferred":[
         "\uc0bc \ub204\uc544"
+    ],
+    "name:krj_x_preferred":[
+        "Sam N\u01b0\u0304a"
+    ],
+    "name:lao_x_preferred":[
+        "\u0e8a\u0eb3 \u0ec0\u0edc\u0eb7\u0ead"
     ],
     "name:lav_x_preferred":[
         "Samn\u012be"
@@ -80,11 +116,20 @@
     "name:lit_x_preferred":[
         "Cham Neua"
     ],
+    "name:lit_x_variant":[
+        "Sam N\u01b0\u0304a"
+    ],
     "name:mar_x_preferred":[
         "\u090f\u0915\u094d\u0938\u092e \u0928\u094d\u092f\u0942\u0906"
     ],
     "name:msa_x_preferred":[
         "Xam Neua"
+    ],
+    "name:msa_x_variant":[
+        "Sam N\u01b0\u0304a"
+    ],
+    "name:mya_x_preferred":[
+        "\u101e\u1036\u1014\u1030\u1038"
     ],
     "name:nld_x_preferred":[
         "Sam Neua"
@@ -92,11 +137,20 @@
     "name:nob_x_preferred":[
         "Xam Neua"
     ],
+    "name:nob_x_variant":[
+        "Sam N\u01b0\u0304a"
+    ],
     "name:pol_x_preferred":[
         "Xam Neua"
     ],
+    "name:pol_x_variant":[
+        "Sam N\u01b0\u0304a"
+    ],
     "name:por_x_preferred":[
         "Xam Neua"
+    ],
+    "name:por_x_variant":[
+        "Sam N\u01b0\u0304a"
     ],
     "name:rus_x_preferred":[
         "\u0421\u0430\u043c\u043d\u044b\u0430"
@@ -107,8 +161,14 @@
     "name:spa_x_preferred":[
         "Xam Neua"
     ],
+    "name:spa_x_variant":[
+        "Sam N\u01b0\u0304a"
+    ],
     "name:swe_x_preferred":[
         "Xam Neua"
+    ],
+    "name:swe_x_variant":[
+        "Sam N\u01b0\u0304a"
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc7\u0bae\u0bcd \u0ba8\u0bc7\u0bb5\u0bc1\u0bb5\u0bbe"
@@ -121,6 +181,9 @@
     ],
     "name:tur_x_preferred":[
         "Xam Neua"
+    ],
+    "name:tur_x_variant":[
+        "Sam N\u01b0\u0304a"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0430\u043c-\u041d\u0435\u0443\u0430"
@@ -135,7 +198,8 @@
         "Xamneua"
     ],
     "name:vie_x_variant":[
-        "Xam Neua"
+        "Xam Neua",
+        "Sam N\u01b0\u0304a"
     ],
     "name:zho_x_preferred":[
         "\u6851\u6012"
@@ -279,7 +343,7 @@
         }
     ],
     "wof:id":421201947,
-    "wof:lastmodified":1636495634,
+    "wof:lastmodified":1690938503,
     "wof:name":"Xam Nua",
     "wof:parent_id":1092030087,
     "wof:placetype":"locality",

--- a/data/856/322/41/85632241.geojson
+++ b/data/856/322/41/85632241.geojson
@@ -49,8 +49,14 @@
     "name:amh_x_variant":[
         "\u120b\u12a6\u1235"
     ],
+    "name:ami_x_preferred":[
+        "Laos"
+    ],
     "name:ang_x_preferred":[
         "Laoland"
+    ],
+    "name:anp_x_preferred":[
+        "\u0932\u093e\u0913\u0938"
     ],
     "name:ara_x_preferred":[
         "\u0644\u0627\u0648\u0633"
@@ -69,6 +75,12 @@
     ],
     "name:ast_x_preferred":[
         "Laos"
+    ],
+    "name:ava_x_preferred":[
+        "\u041b\u0430\u043e\u0441"
+    ],
+    "name:awa_x_preferred":[
+        "\u0932\u093e\u0913\u0938"
     ],
     "name:azb_x_preferred":[
         "\u0644\u0627\u0626\u0648\u0633"
@@ -105,6 +117,9 @@
     ],
     "name:bis_x_preferred":[
         "Laos"
+    ],
+    "name:blk_x_preferred":[
+        "\u101c\u102c\u1021\u102d\u102f\u1001\u1019\u103a\u1038\u1011\u102e"
     ],
     "name:bod_x_preferred":[
         "\u0f63\u0f60\u0f7c\u0f0b\u0f66\u0f74\u0f0d"
@@ -170,6 +185,9 @@
         "La\u00f2s"
     ],
     "name:cym_x_preferred":[
+        "Laos"
+    ],
+    "name:dag_x_preferred":[
         "Laos"
     ],
     "name:dan_x_preferred":[
@@ -313,6 +331,9 @@
     "name:gom_x_preferred":[
         "\u0932\u093e\u0913\u0938"
     ],
+    "name:gpe_x_preferred":[
+        "Laos"
+    ],
     "name:grn_x_preferred":[
         "L\u00e1o"
     ],
@@ -455,6 +476,9 @@
     "name:kor_x_preferred":[
         "\ub77c\uc624\uc2a4"
     ],
+    "name:krj_x_preferred":[
+        "Kalauhan"
+    ],
     "name:kur_x_preferred":[
         "Laos"
     ],
@@ -492,6 +516,9 @@
     "name:lit_x_preferred":[
         "Laosas"
     ],
+    "name:lld_x_preferred":[
+        "Laos"
+    ],
     "name:lmo_x_preferred":[
         "Laos"
     ],
@@ -506,6 +533,9 @@
     ],
     "name:lzh_x_preferred":[
         "\u8001\u64be"
+    ],
+    "name:mad_x_preferred":[
+        "Laos"
     ],
     "name:mai_x_preferred":[
         "\u0932\u093e\u0913\u0938"
@@ -536,6 +566,9 @@
     ],
     "name:mlt_x_preferred":[
         "Laos"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc2\uabe5\uabd1\uabe3\uabc1"
     ],
     "name:mon_x_preferred":[
         "\u041b\u0430\u043e\u0441"
@@ -587,6 +620,9 @@
     ],
     "name:new_x_preferred":[
         "\u0932\u093e\u0913\u0938"
+    ],
+    "name:nia_x_preferred":[
+        "Laos"
     ],
     "name:nld_x_preferred":[
         "Laos"
@@ -747,7 +783,16 @@
     "name:sme_x_preferred":[
         "Laos"
     ],
+    "name:smj_x_preferred":[
+        "La\u00e5vss\u00e5"
+    ],
+    "name:smn_x_preferred":[
+        "Laos"
+    ],
     "name:smo_x_preferred":[
+        "Laos"
+    ],
+    "name:sms_x_preferred":[
         "Laos"
     ],
     "name:sna_x_preferred":[
@@ -830,10 +875,19 @@
     "name:tir_x_preferred":[
         "\u120b\u12a6\u1235"
     ],
+    "name:tok_x_preferred":[
+        "ma Lajo"
+    ],
     "name:ton_x_preferred":[
         "Lau"
     ],
+    "name:ton_x_variant":[
+        "Laosi"
+    ],
     "name:tpi_x_preferred":[
+        "Laos"
+    ],
+    "name:trv_x_preferred":[
         "Laos"
     ],
     "name:tso_x_preferred":[
@@ -872,6 +926,9 @@
     ],
     "name:uzb_x_preferred":[
         "Laos"
+    ],
+    "name:vec_x_preferred":[
+        "L\u00e0os"
     ],
     "name:vep_x_preferred":[
         "Laos"
@@ -1155,7 +1212,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1617827405,
+    "wof:lastmodified":1690938489,
     "wof:name":"Laos",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/734/09/85673409.geojson
+++ b/data/856/734/09/85673409.geojson
@@ -39,8 +39,14 @@
     "name:ben_x_preferred":[
         "\u09ac\u09c1\u0995\u09c7\u0993 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u09ac\u09cb\u0995\u09c7\u0993 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
     "name:ceb_x_preferred":[
         "Khou\u00e8ng Bok\u00e8o"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Bokeo"
     ],
     "name:dan_x_preferred":[
         "Bokeo Province"
@@ -70,7 +76,8 @@
         "Bokeo"
     ],
     "name:fra_x_variant":[
-        "Province de Bokeo"
+        "Province de Bokeo",
+        "Bok\u00e8o"
     ],
     "name:guj_x_preferred":[
         "\u0aac\u0acb\u0a95\u0ac0\u0a93 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
@@ -98,6 +105,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0cac\u0cca\u0c95\u0cc6\u0caf\u0ccb \u0caa\u0ccd\u0cb0\u0cbe\u0c82\u0ca4\u0ccd\u0caf"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d1\u10dd\u10d9\u10d4\u10dd\u10e1 \u10de\u10e0\u10dd\u10d5\u10d8\u10dc\u10ea\u10d8\u10d0"
     ],
     "name:khm_x_preferred":[
         "\u1781\u17c1\u178f\u17d2\u178f \u1794 \u1780\u17c2\u179c"
@@ -144,6 +154,9 @@
     "name:sin_x_preferred":[
         "\u0db6\u0ddd\u0d9a\u0dd2\u0dba\u0ddd \u0db4\u0dc5\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "Bok\u00e8o"
+    ],
     "name:spa_x_preferred":[
         "Provincia de Bokeo"
     ],
@@ -179,6 +192,12 @@
     ],
     "name:war_x_preferred":[
         "Bokeo"
+    ],
+    "name:wuu_x_preferred":[
+        "\u535a\u80f6\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u535a\u81a0\u7701"
     ],
     "name:zho_x_preferred":[
         "\u535a\u80f6\u7701"
@@ -304,7 +323,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1636495631,
+    "wof:lastmodified":1690938494,
     "wof:name":"Bokeo",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/13/85673413.geojson
+++ b/data/856/734/13/85673413.geojson
@@ -39,11 +39,17 @@
     "name:ben_x_preferred":[
         "\u09b2\u09c1\u09af\u09bc\u09be\u0982 \u09a8\u09be\u09ae\u09cd\u09a5\u09be \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u09b2\u09c1\u09af\u09bc\u09be\u0982 \u09a8\u09be\u09ae\u09a5\u09be \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
     "name:bul_x_preferred":[
         "\u041b\u043e\u0443\u0430\u043d\u0433\u043d\u0430\u043c\u0442\u0445\u0430"
     ],
     "name:ceb_x_preferred":[
         "Louangnamtha"
+    ],
+    "name:ceb_x_variant":[
+        "Lalawigan sa L\u016bang Namth\u0101"
     ],
     "name:cym_x_preferred":[
         "Talaith Luang Namtha"
@@ -63,7 +69,8 @@
     "name:eng_x_variant":[
         "Louang Namtha",
         "Louangnamtha",
-        "Luang Namtha Province"
+        "Luang Namtha Province",
+        "L\u016bang Namth\u0101"
     ],
     "name:epo_x_preferred":[
         "Provinco Luang Namtha"
@@ -78,7 +85,8 @@
         "Luang Namtha"
     ],
     "name:fra_x_variant":[
-        "Province de Luang Namtha"
+        "Province de Luang Namtha",
+        "Louang-Namtha"
     ],
     "name:guj_x_preferred":[
         "\u0ab2\u0ac1\u0a86\u0a82\u0a97 \u0aa8\u0abe\u0aae\u0acd\u0aa5\u0abe \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
@@ -107,8 +115,14 @@
     "name:kan_x_preferred":[
         "\u0cb2\u0cc1\u0cb5\u0cbe\u0c82\u0c97\u0ccd \u0ca8\u0cae\u0ccd\u0ca4\u0cbe \u0caa\u0ccd\u0cb0\u0cbe\u0c82\u0ca4\u0ccd\u0caf"
     ],
+    "name:khm_x_preferred":[
+        "\u1781\u17c1\u178f\u17d2\u178f\u17a0\u17d2\u179b\u17bd\u1784\u178e\u17b6\u17c6\u1790\u17b6"
+    ],
     "name:kor_x_preferred":[
         "\ub8e8\uc559\ub0a8\ud0c0 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ub8e8\uc559\ub0a8\ud0c0\uc8fc"
     ],
     "name:lao_x_preferred":[
         "\u0ec1\u0e82\u0ea7\u0e87\u0eab\u0ebc\u0ea7\u0e87\u0e99\u0ecd\u0ec9\u0eb2\u0e97\u0eb2"
@@ -124,6 +138,9 @@
     ],
     "name:msa_x_preferred":[
         "Wilayah Louang Namtha"
+    ],
+    "name:mya_x_preferred":[
+        "\u101c\u103d\u1019\u103a\u1014\u1019\u103a\u1011\u102c\u1015\u103c\u100a\u103a\u1014\u101a\u103a"
     ],
     "name:nan_x_preferred":[
         "Luang Namtha S\u00e9ng"
@@ -145,6 +162,9 @@
     ],
     "name:sin_x_preferred":[
         "\u0dbd\u0dd4\u0d85\u0db1\u0dca\u0d9c\u0dca \u0db1\u0db8\u0dca\u0dad \u0db4\u0dc5\u0dcf\u0dad"
+    ],
+    "name:som_x_preferred":[
+        "L\u016bang Namth\u0101"
     ],
     "name:spa_x_preferred":[
         "Louang Namtha"
@@ -182,6 +202,15 @@
     ],
     "name:war_x_preferred":[
         "Luang Nam Tha"
+    ],
+    "name:war_x_variant":[
+        "L\u016bang Namth\u0101"
+    ],
+    "name:wuu_x_preferred":[
+        "\u7405\u5357\u5854\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u7405\u5357\u4ed6\u7701"
     ],
     "name:zho_x_preferred":[
         "\u7405\u5357\u5854\u7701"
@@ -309,7 +338,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1636495631,
+    "wof:lastmodified":1690938496,
     "wof:name":"Louang Namtha",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/17/85673417.geojson
+++ b/data/856/734/17/85673417.geojson
@@ -39,11 +39,20 @@
     "name:ben_x_preferred":[
         "\u09b8\u09be\u0987\u09a8\u09bf\u09af\u09bc\u09be\u09ac\u09c1\u09b2\u09bf \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u09b8\u09c8\u09a8\u09cd\u09af\u09ac\u09c1\u09b2\u09bf \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
     "name:cat_x_preferred":[
         "Prov\u00edncia de Sainyabuli"
     ],
     "name:ceb_x_preferred":[
         "Xaignabouli"
+    ],
+    "name:ckb_x_preferred":[
+        "\u067e\u0627\u0631\u06ce\u0632\u06af\u0627\u06cc \u0633\u0627\u06cc\u0646\u0627\u0628\u0648\u0644\u06cc"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Sainyabuli"
     ],
     "name:dan_x_preferred":[
         "Sainyabuli Province"
@@ -58,7 +67,8 @@
         "Xiagnabouli"
     ],
     "name:eng_x_variant":[
-        "Sainyabuli Province"
+        "Sainyabuli Province",
+        "Sainyab\u016bl\u012b"
     ],
     "name:epo_x_preferred":[
         "Provinco Sainjabuli"
@@ -77,6 +87,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac8\u0aa8\u0acd\u0aaf\u0abe\u0aac\u0ac1\u0ab2\u0ac0 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05e1\u05d0\u05d9\u05e0\u05d1\u05d5\u05dc\u05d9"
     ],
     "name:hin_x_preferred":[
         "\u0938\u0948\u0902\u092f\u093e\u092c\u0941\u0932\u0940 \u092a\u094d\u0930\u093e\u0928\u094d\u0924"
@@ -107,6 +120,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc0ac\uc774\ub0d0\ubd88\ub9ac \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc0ac\uc774\ub0d0\ubd88\ub9ac\uc8fc"
     ],
     "name:lao_x_preferred":[
         "\u0ec1\u0e82\u0ea7\u0e87\u0ec4\u0e8a\u0e8d\u0eb0\u0e9a\u0eb9\u0ea5\u0eb5"
@@ -147,6 +163,9 @@
     "name:sin_x_preferred":[
         "\u0dc3\u0dda\u0dba\u0dcf\u0db1\u0dca\u0db6\u0dd4\u0dbd\u0dd2 \u0db4\u0dc5\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "Sainyab\u016bl\u012b"
+    ],
     "name:spa_x_preferred":[
         "Provincia de Sainyabuli"
     ],
@@ -183,6 +202,15 @@
     ],
     "name:war_x_preferred":[
         "Sainyabuli"
+    ],
+    "name:war_x_variant":[
+        "Sainyab\u016bl\u012b"
+    ],
+    "name:wuu_x_preferred":[
+        "\u6c99\u8036\u6b66\u91cc\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u6c99\u8036\u6b66\u5229\u7701"
     ],
     "name:zho_x_preferred":[
         "\u6c99\u8036\u6b66\u91cc\u7701"
@@ -308,7 +336,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1636495630,
+    "wof:lastmodified":1690938493,
     "wof:name":"Xaignabouri",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/23/85673423.geojson
+++ b/data/856/734/23/85673423.geojson
@@ -39,17 +39,29 @@
     "name:ben_x_preferred":[
         "\u099a\u09ae\u09cd\u09aa\u09be\u0995\u0995 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u099a\u09be\u09ae\u09aa\u09be\u09b8\u09be\u0995 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
+    "name:cat_x_preferred":[
+        "Champasak"
+    ],
     "name:ceb_x_preferred":[
         "Champasak"
     ],
     "name:chv_x_preferred":[
         "\u0427\u0430\u043c\u043f\u0430\u0441\u0430\u043a"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Champasak"
+    ],
     "name:dan_x_preferred":[
         "Champasak Province"
     ],
     "name:deu_x_preferred":[
         "Provinz Champasak"
+    ],
+    "name:diq_x_preferred":[
+        "\u00c7ampasak"
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03c3\u03b1\u03bc\u03c0\u03b1\u03c3\u03ac\u03ba"
@@ -73,10 +85,14 @@
         "Champassak"
     ],
     "name:fra_x_variant":[
-        "province de Champassak"
+        "province de Champassak",
+        "Champasak"
     ],
     "name:guj_x_preferred":[
         "\u0a9a\u0a82\u0aaa\u0abe\u0ab8\u0a95 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05e6'\u05d0\u05de\u05e4\u05e1\u05d0\u05e7"
     ],
     "name:hin_x_preferred":[
         "\u091a\u092e\u094d\u092a\u093e\u0938\u0915 \u092a\u094d\u0930\u093e\u0928\u094d\u0924"
@@ -109,7 +125,8 @@
         "\u0e88\u0eb3\u0e9b\u0eb2\u0eaa\u0eb1\u0e81"
     ],
     "name:lao_x_variant":[
-        "\u0ec1\u0e82\u0ea7\u0e87\u0e88\u0ecd\u0eb2\u0e9b\u0eb2\u0eaa\u0eb1\u0e81"
+        "\u0ec1\u0e82\u0ea7\u0e87\u0e88\u0ecd\u0eb2\u0e9b\u0eb2\u0eaa\u0eb1\u0e81",
+        "\u0ec1\u0e82\u0ea7\u0e87\u0e88\u0eb3\u0e9b\u0eb2\u0eaa\u0eb1\u0e81"
     ],
     "name:lav_x_preferred":[
         "\u010camp\u0101sakas province"
@@ -138,6 +155,9 @@
     "name:nob_x_preferred":[
         "Champasack"
     ],
+    "name:pnb_x_preferred":[
+        "\u0686\u0627\u0645\u067e\u0627\u0633\u0627\u06a9 \u0635\u0648\u0628\u06c1"
+    ],
     "name:pol_x_preferred":[
         "Prowincja Champasak"
     ],
@@ -149,6 +169,9 @@
     ],
     "name:sin_x_preferred":[
         "\u0da0\u0db8\u0dca\u0db4\u0dc3\u0d9a\u0dca \u0db4\u0dc5\u0dcf\u0dad"
+    ],
+    "name:som_x_preferred":[
+        "Champasak Province"
     ],
     "name:spa_x_preferred":[
         "Provincia de Champasak"
@@ -171,6 +194,9 @@
     "name:tur_x_preferred":[
         "Champasak Province"
     ],
+    "name:tur_x_variant":[
+        "\u00c7ampasak B\u00f6lgesi"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u044f\u043c\u043f\u0430\u0441\u0430\u043a"
     ],
@@ -188,6 +214,12 @@
     ],
     "name:war_x_preferred":[
         "Champasak"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5360\u5df4\u585e\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u5360\u5df4\u585e\u7701"
     ],
     "name:zho_x_preferred":[
         "\u5360\u5df4\u585e\u7701"
@@ -313,7 +345,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1636495631,
+    "wof:lastmodified":1690938495,
     "wof:name":"Champasak",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/27/85673427.geojson
+++ b/data/856/734/27/85673427.geojson
@@ -42,14 +42,23 @@
     "name:ben_x_preferred":[
         "\u09b8\u09be\u09b2\u09ad\u09be\u09a8 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u09b8\u09be\u09b2\u09be\u09ac\u09a8 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
     "name:ceb_x_preferred":[
         "Salavan"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Salavan"
     ],
     "name:dan_x_preferred":[
         "Salavan Province"
     ],
     "name:deu_x_preferred":[
         "Provinz Salavan"
+    ],
+    "name:diq_x_preferred":[
+        "Salavan"
     ],
     "name:ell_x_preferred":[
         "\u03a3\u03b1\u03bb\u03b1\u03b2\u03ac\u03bd"
@@ -73,10 +82,14 @@
         "Saravane"
     ],
     "name:fra_x_variant":[
-        "Province de Saravane"
+        "Province de Saravane",
+        "Salavan"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0abe\u0ab2\u0ab5\u0abe\u0aa8 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05e1\u05dc\u05d1\u05df"
     ],
     "name:hin_x_preferred":[
         "\u0938\u0932\u093e\u0935\u093e\u0928 \u092a\u094d\u0930\u093e\u0928\u094d\u0924"
@@ -107,6 +120,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc0b4\ub77c\uc644 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc0b4\ub77c\uc644\uc8fc"
     ],
     "name:lao_x_preferred":[
         "\u0ec1\u0e82\u0ea7\u0e87\u0eaa\u0eb2\u0ea5\u0eb0\u0ea7\u0eb1\u0e99"
@@ -144,6 +160,9 @@
     "name:sin_x_preferred":[
         "\u0dc3\u0dbd\u0dc0\u0db1\u0dca \u0db4\u0dc5\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "Salavan"
+    ],
     "name:spa_x_preferred":[
         "Salavan"
     ],
@@ -180,6 +199,12 @@
     ],
     "name:war_x_preferred":[
         "Salavan"
+    ],
+    "name:wuu_x_preferred":[
+        "\u6c99\u62c9\u6e7e\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u6c99\u62c9\u7063\u7701"
     ],
     "name:zho_x_preferred":[
         "\u6c99\u62c9\u6e7e\u7701"
@@ -305,7 +330,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1636495630,
+    "wof:lastmodified":1690938492,
     "wof:name":"Saravan",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/29/85673429.geojson
+++ b/data/856/734/29/85673429.geojson
@@ -42,8 +42,14 @@
     "name:ben_x_preferred":[
         "\u09b8\u09cd\u09af\u09be\u09ad\u09be\u09a8\u09cd\u09a8\u09be\u0996\u09c7\u09a4 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u09b8\u09be\u09ac\u09a8\u09cd\u09a8\u09be\u0996\u09c7\u09a4 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
     "name:ceb_x_preferred":[
         "Khou\u00e8ng Savannakh\u00e9t"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Savannakhet"
     ],
     "name:dan_x_preferred":[
         "Savannakhet Province"
@@ -73,7 +79,8 @@
         "Savannakhet"
     ],
     "name:fra_x_variant":[
-        "Province de Savannakhet"
+        "Province de Savannakhet",
+        "Savannakh\u00e9t"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ab5\u0abe\u0aa8\u0acd\u0aa8\u0abe\u0a96\u0ac7\u0aa4 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
@@ -99,8 +106,17 @@
     "name:kan_x_preferred":[
         "\u0cb8\u0cb5\u0ca8\u0ccd\u0ca8\u0cbe\u0c96\u0cc6\u0ca4\u0ccd \u0caa\u0ccd\u0cb0\u0cbe\u0c82\u0ca4\u0ccd\u0caf"
     ],
+    "name:khm_x_preferred":[
+        "\u1781\u17c1\u178f\u17d2\u178f\u200b\u179f\u17bd\u1782\u17cc\u1781\u17c1\u178f\u17d2\u178f"
+    ],
     "name:kor_x_preferred":[
         "\uc0ac\uc644\ub098\ucf13 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc0ac\uc644\ub098\ucf13\uc8fc"
+    ],
+    "name:krj_x_preferred":[
+        "Savannakh\u0113t"
     ],
     "name:lao_x_preferred":[
         "\u0ec1\u0e82\u0ea7\u0e87\u0eaa\u0eb0\u0eab\u0ea7\u0eb1\u0e99\u0e99\u0eb0\u0ec0\u0e82\u0e94"
@@ -144,6 +160,9 @@
     "name:sin_x_preferred":[
         "\u0dc3\u0dc0\u0db1\u0dca\u0db1\u0d9b\u0dd9\u0dad\u0dca \u0db4\u0dc5\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "Savannakh\u0113t"
+    ],
     "name:spa_x_preferred":[
         "Provincia de Savannakhet"
     ],
@@ -180,6 +199,12 @@
     ],
     "name:war_x_preferred":[
         "Savannakhet"
+    ],
+    "name:wuu_x_preferred":[
+        "\u6c99\u6e7e\u62ff\u5409\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u6c99\u7063\u62ff\u5409\u7701"
     ],
     "name:zho_x_preferred":[
         "\u6c99\u6e7e\u62ff\u5409\u7701"
@@ -307,7 +332,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1614895003,
+    "wof:lastmodified":1690938492,
     "wof:name":"Savannakh\u00e9t",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/33/85673433.geojson
+++ b/data/856/734/33/85673433.geojson
@@ -34,11 +34,17 @@
     "name:bel_x_preferred":[
         "\u0412\u2019\u0435\u043d\u0446\u044c\u044f\u043d"
     ],
+    "name:ben_x_preferred":[
+        "\u09ad\u09bf\u09af\u09bc\u09c7\u09a8\u099a\u09be\u09a8 \u09aa\u09cd\u09b0\u09bf\u09ab\u09c7\u0995\u099a\u09be\u09b0"
+    ],
     "name:cat_x_preferred":[
         "Prefectura de Vientiane"
     ],
     "name:ceb_x_preferred":[
         "Vientiane Prefecture"
+    ],
+    "name:ceb_x_variant":[
+        "Biyentiyan"
     ],
     "name:deu_x_preferred":[
         "Pr\u00e4fektur Vientiane"
@@ -47,7 +53,8 @@
         "Viangchan"
     ],
     "name:eng_x_variant":[
-        "Vientiane Prefecture"
+        "Vientiane Prefecture",
+        "Vientiane"
     ],
     "name:epo_x_preferred":[
         "Prefektejo Vjentiano"
@@ -70,6 +77,9 @@
     "name:hun_x_preferred":[
         "Vienti\u00e1n prefekt\u00fara"
     ],
+    "name:ilo_x_preferred":[
+        "Bientian"
+    ],
     "name:ind_x_preferred":[
         "Prefektur Vientiane"
     ],
@@ -79,8 +89,14 @@
     "name:jpn_x_preferred":[
         "\u30f4\u30a3\u30a8\u30f3\u30c1\u30e3\u30f3\u90fd"
     ],
+    "name:khm_x_preferred":[
+        "\u179a\u178a\u17d2\u178b\u1792\u17b6\u1793\u17b8\u179c\u17c0\u1784\u1785\u1793\u17d2\u1791\u1793\u17cd"
+    ],
     "name:kor_x_preferred":[
         "\ube44\uc5d4\ud2f0\uc548 \ub3c4"
+    ],
+    "name:krj_x_preferred":[
+        "Biyentiyan"
     ],
     "name:lao_x_preferred":[
         "\u0e99\u0eb0\u0e84\u0ead\u0e99\u0eab\u0ebc\u0ea7\u0e87\u0ea7\u0ebd\u0e87\u0e88\u0eb1\u0e99"
@@ -100,6 +116,9 @@
     "name:nno_x_preferred":[
         "Viengchan-prefekturet"
     ],
+    "name:pam_x_preferred":[
+        "Bientian"
+    ],
     "name:pol_x_preferred":[
         "Prefektura Wientian"
     ],
@@ -112,8 +131,17 @@
     "name:spa_x_preferred":[
         "Prefectura de Vienti\u00e1n"
     ],
+    "name:spa_x_variant":[
+        "Vienti\u00e1n"
+    ],
+    "name:tgl_x_preferred":[
+        "Biyentiyan"
+    ],
     "name:tha_x_preferred":[
         "\u0e19\u0e04\u0e23\u0e2b\u0e25\u0e27\u0e07\u0e40\u0e27\u0e35\u0e22\u0e07\u0e08\u0e31\u0e19\u0e17\u0e19\u0e4c"
+    ],
+    "name:tur_x_preferred":[
+        "Vientiane \u00d6zel Y\u00f6netim B\u00f6lgesi"
     ],
     "name:und_x_variant":[
         "\u0ea7\u0ebd\u0e87\u0e88\u0eb1\u0e99"
@@ -123,6 +151,9 @@
     ],
     "name:war_x_preferred":[
         "Vientiane"
+    ],
+    "name:war_x_variant":[
+        "Biyentiyan"
     ],
     "name:zho_x_preferred":[
         "\u6c38\u73cd\u5e02"
@@ -235,7 +266,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1614895003,
+    "wof:lastmodified":1690938492,
     "wof:name":"Vientiane (prefecture)",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/37/85673437.geojson
+++ b/data/856/734/37/85673437.geojson
@@ -33,8 +33,14 @@
     "name:bel_x_preferred":[
         "\u0412\u2019\u0435\u043d\u0446\u044c\u044f\u043d"
     ],
+    "name:ben_x_preferred":[
+        "\u09ad\u09bf\u09af\u09bc\u09c7\u09a8\u099a\u09be\u09a8 \u09aa\u09cd\u09b0\u09bf\u09ab\u09c7\u0995\u099a\u09be\u09b0"
+    ],
     "name:ceb_x_preferred":[
         "Vientiane Prefecture"
+    ],
+    "name:ceb_x_variant":[
+        "Biyentiyan"
     ],
     "name:deu_x_preferred":[
         "Pr\u00e4fektur Vientiane"
@@ -70,14 +76,23 @@
     "name:hun_x_preferred":[
         "Vienti\u00e1n prefekt\u00fara"
     ],
+    "name:ilo_x_preferred":[
+        "Bientian"
+    ],
     "name:ind_x_preferred":[
         "Prefektur Vientiane"
     ],
     "name:jpn_x_preferred":[
         "\u30f4\u30a3\u30a8\u30f3\u30c1\u30e3\u30f3\u90fd"
     ],
+    "name:khm_x_preferred":[
+        "\u179a\u178a\u17d2\u178b\u1792\u17b6\u1793\u17b8\u179c\u17c0\u1784\u1785\u1793\u17d2\u1791\u1793\u17cd"
+    ],
     "name:kor_x_preferred":[
         "\ube44\uc5d4\ud2f0\uc548 \ub3c4"
+    ],
+    "name:krj_x_preferred":[
+        "Biyentiyan"
     ],
     "name:lao_x_preferred":[
         "\u0e99\u0eb0\u0e84\u0ead\u0e99\u0eab\u0ebc\u0ea7\u0e87\u0ea7\u0ebd\u0e87\u0e88\u0eb1\u0e99"
@@ -97,6 +112,9 @@
     "name:nno_x_preferred":[
         "Viengchan-prefekturet"
     ],
+    "name:pam_x_preferred":[
+        "Bientian"
+    ],
     "name:pol_x_preferred":[
         "Prefektura Wientian"
     ],
@@ -105,6 +123,12 @@
     ],
     "name:rus_x_preferred":[
         "\u0412\u044c\u0435\u043d\u0442\u044c\u044f\u043d"
+    ],
+    "name:spa_x_preferred":[
+        "Vienti\u00e1n"
+    ],
+    "name:tgl_x_preferred":[
+        "Biyentiyan"
     ],
     "name:tha_x_preferred":[
         "\u0e19\u0e04\u0e23\u0e2b\u0e25\u0e27\u0e07\u0e40\u0e27\u0e35\u0e22\u0e07\u0e08\u0e31\u0e19\u0e17\u0e19\u0e4c"
@@ -118,6 +142,9 @@
     ],
     "name:war_x_preferred":[
         "Vientiane"
+    ],
+    "name:war_x_variant":[
+        "Biyentiyan"
     ],
     "name:zho_x_preferred":[
         "\u6c38\u73cd\u5e02"
@@ -229,7 +256,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1636495631,
+    "wof:lastmodified":1690938494,
     "wof:name":"Vientiane",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/41/85673441.geojson
+++ b/data/856/734/41/85673441.geojson
@@ -36,8 +36,20 @@
     "name:ben_x_preferred":[
         "\u099c\u09bf\u09af\u09bc\u09be\u0982\u0996\u09c1\u09af\u09bc\u09be\u0982 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u09b8\u09bf\u09af\u09bc\u09be\u0982\u0996\u09c1\u09af\u09bc\u09be\u0982 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
+    "name:cat_x_preferred":[
+        "S\u012bang Khw\u0101ng"
+    ],
     "name:ceb_x_preferred":[
         "Xiangkhouang"
+    ],
+    "name:ceb_x_variant":[
+        "S\u012bang Khw\u0101ng"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Xiangkhouang"
     ],
     "name:dan_x_preferred":[
         "Xiangkhouang Province"
@@ -67,10 +79,14 @@
         "Xieng Khouang"
     ],
     "name:fra_x_variant":[
-        "Province de Xieng Khouang"
+        "Province de Xieng Khouang",
+        "Xiang-Khouang"
     ],
     "name:guj_x_preferred":[
         "\u0a9d\u0ac0\u0aaf\u0abe\u0a82\u0a97\u0a96\u0acc\u0a86\u0a82\u0a97 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d9\u05d9\u05e0\u05e7\u05d4\u05d5\u05d0\u05e0\u05d2"
     ],
     "name:hin_x_preferred":[
         "\u0938\u093f\u090f\u0902\u0917\u0916\u0941\u0905\u0902\u0917 \u092a\u094d\u0930\u093e\u0928\u094d\u0924"
@@ -78,11 +94,17 @@
     "name:hrv_x_preferred":[
         "Xiang Khouang"
     ],
+    "name:hrv_x_variant":[
+        "S\u012bang Khw\u0101ng"
+    ],
     "name:hun_x_preferred":[
         "Sziangkhuang tartom\u00e1ny"
     ],
     "name:ind_x_preferred":[
         "Provinsi Xiangkhoang"
+    ],
+    "name:ind_x_variant":[
+        "S\u012bang Khw\u0101ng"
     ],
     "name:ita_x_preferred":[
         "provincia di Xiangkhoang"
@@ -114,6 +136,9 @@
     "name:msa_x_preferred":[
         "Wilayah Xiangkhouang"
     ],
+    "name:msa_x_variant":[
+        "S\u012bang Khw\u0101ng"
+    ],
     "name:nan_x_preferred":[
         "Xiangkhouang S\u00e9ng"
     ],
@@ -135,11 +160,20 @@
     "name:sin_x_preferred":[
         "\u0d9a\u0dd2\u0dc3\u0dca\u0dba\u0dd0\u0db1\u0dca\u0d9c\u0dca\u0d9a\u0dd4\u0d87\u0db1\u0dca\u0d9c\u0dca \u0db4\u0dbd\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "S\u012bang Khw\u0101ng"
+    ],
     "name:spa_x_preferred":[
         "Provincia de Xiangkhoang"
     ],
+    "name:spa_x_variant":[
+        "S\u012bang Khw\u0101ng"
+    ],
     "name:swe_x_preferred":[
         "Xieng Khouang"
+    ],
+    "name:swe_x_variant":[
+        "S\u012bang Khw\u0101ng"
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bcd\u0bb8\u0bbf\u0b99\u0bcd\u0b95\u0bcd\u0bb9\u0bb5\u0bc1\u0b99\u0bcd \u0bae\u0bbe\u0b95\u0bbe\u0ba3\u0bae\u0bcd"
@@ -156,6 +190,9 @@
     "name:tur_x_preferred":[
         "Xiengkhuang"
     ],
+    "name:tur_x_variant":[
+        "S\u012bang Khw\u0101ng"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0456\u0430\u043d\u0433\u043a\u0445\u0443\u0430\u043d\u0433"
     ],
@@ -171,6 +208,15 @@
     ],
     "name:war_x_preferred":[
         "Xieng Khuang"
+    ],
+    "name:war_x_variant":[
+        "S\u012bang Khw\u0101ng"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5ddd\u5739\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u5ddd\u58d9\u7701"
     ],
     "name:zho_x_preferred":[
         "\u5ddd\u5739\u7701"
@@ -282,7 +328,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1614895004,
+    "wof:lastmodified":1690938495,
     "wof:name":"Xiangkhoang",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/47/85673447.geojson
+++ b/data/856/734/47/85673447.geojson
@@ -36,14 +36,29 @@
     "name:ara_x_preferred":[
         "\u0645\u062d\u0627\u0641\u0638\u0629 \u0647\u0648\u0627 \u0641\u0627\u0646"
     ],
+    "name:bcl_x_preferred":[
+        "H\u016baphan"
+    ],
     "name:ben_x_preferred":[
         "\u09b9\u09be\u0989\u09aa\u09be\u09a8\u09b9 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
+    "name:ben_x_variant":[
+        "\u09b9\u09c1\u09af\u09bc\u09be\u09ab\u09be\u09a8 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
     "name:bul_x_preferred":[
         "\u0425\u043e\u0443\u0430\u043f\u0445\u0430\u043d"
     ],
+    "name:cat_x_preferred":[
+        "Houaphan"
+    ],
     "name:ceb_x_preferred":[
         "Houaphan"
+    ],
+    "name:ceb_x_variant":[
+        "H\u016baphan"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Houaphanh"
     ],
     "name:dan_x_preferred":[
         "Houaphanh Province"
@@ -58,7 +73,8 @@
         "Houaphan"
     ],
     "name:eng_x_variant":[
-        "Houaphanh Province"
+        "Houaphanh Province",
+        "H\u016baphan"
     ],
     "name:epo_x_preferred":[
         "Provinco Huaphanh"
@@ -78,6 +94,12 @@
     "name:guj_x_preferred":[
         "\u0ab9\u0acc\u0a86\u0aab\u0a82\u0ab9 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d7\u05d5\u05d0\u05d5\u05e4\u05df"
+    ],
+    "name:hil_x_preferred":[
+        "H\u016baphan"
+    ],
     "name:hin_x_preferred":[
         "\u0939\u0941\u0906\u092b\u093e\u0928\u094d\u0939 \u092a\u094d\u0930\u093e\u0928\u094d\u0924"
     ],
@@ -86,6 +108,9 @@
     ],
     "name:hun_x_preferred":[
         "Huaphan tartom\u00e1ny"
+    ],
+    "name:ilo_x_preferred":[
+        "H\u016baphan"
     ],
     "name:ind_x_preferred":[
         "Provinsi Houaphan"
@@ -107,6 +132,9 @@
     ],
     "name:kor_x_variant":[
         "\ud6c4\uc544\ud310\uc8fc"
+    ],
+    "name:krj_x_preferred":[
+        "H\u016baphan"
     ],
     "name:lao_x_preferred":[
         "\u0eab\u0ebb\u0ea7\u0e9e\u0eb1\u0e99"
@@ -135,6 +163,12 @@
     "name:nob_x_preferred":[
         "Hua Phan"
     ],
+    "name:pag_x_preferred":[
+        "H\u016baphan"
+    ],
+    "name:pam_x_preferred":[
+        "H\u016baphan"
+    ],
     "name:pol_x_preferred":[
         "Prowincja Houaphan"
     ],
@@ -147,8 +181,14 @@
     "name:sin_x_preferred":[
         "\u0dc4\u0ddc\u0dc0\u0dcf\u0db4\u0db1\u0dca\u0dc4\u0dca \u0db4\u0dc5\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "Houaphanh Province"
+    ],
     "name:spa_x_preferred":[
         "Houaphan"
+    ],
+    "name:spa_x_variant":[
+        "H\u016baphan"
     ],
     "name:swe_x_preferred":[
         "Hua Phan"
@@ -161,6 +201,9 @@
     ],
     "name:tgk_x_preferred":[
         "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u04b2\u043e\u0443\u0430\u043f\u0430\u043d"
+    ],
+    "name:tgl_x_preferred":[
+        "H\u016baphan"
     ],
     "name:tha_x_preferred":[
         "\u0e41\u0e02\u0e27\u0e07\u0e2b\u0e31\u0e27\u0e1e\u0e31\u0e19"
@@ -182,6 +225,15 @@
     ],
     "name:war_x_preferred":[
         "Hua Phan"
+    ],
+    "name:war_x_variant":[
+        "H\u016baphan"
+    ],
+    "name:wuu_x_preferred":[
+        "\u534e\u6f58\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u83ef\u6f58\u7701"
     ],
     "name:zho_x_preferred":[
         "\u534e\u6f58\u7701"
@@ -309,7 +361,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1614895004,
+    "wof:lastmodified":1690938496,
     "wof:name":"Houaphan",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/51/85673451.geojson
+++ b/data/856/734/51/85673451.geojson
@@ -42,6 +42,9 @@
     "name:ben_x_preferred":[
         "\u09b2\u09c1\u09af\u09bc\u09be\u0982 \u09aa\u09cd\u09b0\u09be\u09ac\u09be\u0982 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:cat_x_preferred":[
+        "L\u016bang Phab\u0101ng"
+    ],
     "name:dan_x_preferred":[
         "Luang Prabang Province"
     ],
@@ -63,6 +66,9 @@
     "name:fin_x_preferred":[
         "Louangphabang"
     ],
+    "name:fin_x_variant":[
+        "L\u016bang Phab\u0101ng"
+    ],
     "name:fra_x_preferred":[
         "Luang Prabang"
     ],
@@ -81,6 +87,9 @@
     "name:hun_x_preferred":[
         "Luangprabang tartom\u00e1ny"
     ],
+    "name:hye_x_preferred":[
+        "\u053c\u0578\u0582\u0561\u0576\u0563 \u0553\u0580\u0561\u0562\u0561\u0576\u0563"
+    ],
     "name:ind_x_preferred":[
         "Provinsi Louangphabang"
     ],
@@ -98,6 +107,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub8e8\uc559\ud504\ub77c\ubc29 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ub8e8\uc559\ud504\ub77c\ubc29\uc8fc"
     ],
     "name:lao_x_preferred":[
         "\u0ec1\u0e82\u0ea7\u0e87\u0eab\u0ebc\u0ea7\u0e87\u0e9e\u0eb0\u0e9a\u0eb2\u0e87"
@@ -171,6 +183,15 @@
     ],
     "name:war_x_preferred":[
         "Luang Prabang"
+    ],
+    "name:war_x_variant":[
+        "L\u016bang Phab\u0101ng"
+    ],
+    "name:wuu_x_preferred":[
+        "\u7405\u52c3\u62c9\u90a6\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u9f8d\u5e15\u90a6\u7701"
     ],
     "name:zho_x_preferred":[
         "\u7405\u52c3\u62c9\u90a6\u7701"
@@ -296,7 +317,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1614895002,
+    "wof:lastmodified":1690938491,
     "wof:name":"Luangphrabang",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/53/85673453.geojson
+++ b/data/856/734/53/85673453.geojson
@@ -42,8 +42,14 @@
     "name:ben_x_preferred":[
         "\u0989\u09af\u09bc\u09be\u09a1\u09cb\u09ae\u09af\u09be\u09af\u09bc \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u0989\u09a6\u09cb\u09ae\u09b8\u09be\u0987 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
     "name:ceb_x_preferred":[
         "Khou\u00e8ng Oud\u00f4mxai"
+    ],
+    "name:ceb_x_variant":[
+        "Udomsai"
     ],
     "name:cym_x_preferred":[
         "Talaith Oudomxay"
@@ -61,7 +67,8 @@
         "Oudomxai"
     ],
     "name:eng_x_variant":[
-        "Oudomxay Province"
+        "Oudomxay Province",
+        "Udomsai"
     ],
     "name:epo_x_preferred":[
         "Provinco Udomsai"
@@ -76,10 +83,14 @@
         "Oudomxay"
     ],
     "name:fra_x_variant":[
-        "Province d'Oudomxay"
+        "Province d'Oudomxay",
+        "Oud\u00f4mxai"
     ],
     "name:guj_x_preferred":[
         "\u0a91\u0aa1\u0acb\u0aae\u0acd\u0a95\u0acd\u0ab8\u0ac7 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d0\u05d5\u05d3\u05d5\u05de\u05e9\u05d9"
     ],
     "name:hin_x_preferred":[
         "\u0909\u0921\u094b\u092e\u0938\u093e\u090f \u092a\u094d\u0930\u093e\u0928\u094d\u0924"
@@ -144,8 +155,14 @@
     "name:sin_x_preferred":[
         "\u0d94\u0d8b\u0da9\u0ddc\u0db8\u0dca\u0d9a\u0dca\u0dc3\u0dda \u0db4\u0dc5\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "Udomsai"
+    ],
     "name:spa_x_preferred":[
         "Provincia de Oudomxay"
+    ],
+    "name:spa_x_variant":[
+        "Udomsai"
     ],
     "name:swe_x_preferred":[
         "Udomxai"
@@ -179,6 +196,12 @@
     ],
     "name:war_x_preferred":[
         "Udomxai"
+    ],
+    "name:wuu_x_preferred":[
+        "\u4e4c\u591a\u59c6\u585e\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u5967\u51ac\u585e\u7701"
     ],
     "name:zho_x_preferred":[
         "\u4e4c\u591a\u59c6\u585e\u7701"
@@ -304,7 +327,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1614895004,
+    "wof:lastmodified":1690938494,
     "wof:name":"Oud\u00f4mxai",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/59/85673459.geojson
+++ b/data/856/734/59/85673459.geojson
@@ -37,8 +37,14 @@
     "name:ara_x_preferred":[
         "\u0645\u062d\u0627\u0641\u0638\u0629 \u0641\u0648\u0646\u063a \u0633\u0627\u0644\u064a"
     ],
+    "name:bel_x_preferred":[
+        "\u041f\u0445\u0430\u043d\u0433\u0441\u0430\u043b\u0456"
+    ],
     "name:ben_x_preferred":[
         "\u09ab\u0982\u09b8\u09be\u09b2\u09bf \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
+    "name:ben_x_variant":[
+        "\u09ab\u09cb\u0982\u09b8\u09be\u09b2\u09bf \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
     "name:cat_x_preferred":[
         "Prov\u00edncia de Phongsali"
@@ -112,6 +118,9 @@
     "name:kor_x_preferred":[
         "\ud401\uc0b4\ub9ac \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ud401\uc0b4\ub9ac\uc8fc"
+    ],
     "name:lao_x_preferred":[
         "\u0ec1\u0e82\u0ea7\u0e87\u0e9c\u0ebb\u0ec9\u0e87\u0eaa\u0eb2\u0ea5\u0eb5"
     ],
@@ -147,6 +156,9 @@
     ],
     "name:sin_x_preferred":[
         "\u0db4\u0ddc\u0db1\u0dca\u0d9c\u0dca\u0dc3\u0dca\u0dbd\u0dda \u0db4\u0dc5\u0dcf\u0dad"
+    ],
+    "name:som_x_preferred":[
+        "Phongs\u0101l\u012b"
     ],
     "name:spa_x_preferred":[
         "Provincia de Phongsali"
@@ -184,6 +196,12 @@
     ],
     "name:war_x_preferred":[
         "Phongsali"
+    ],
+    "name:wuu_x_preferred":[
+        "\u4e30\u6c99\u91cc\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u8c50\u6c99\u5229\u7701"
     ],
     "name:zho_x_preferred":[
         "\u4e30\u6c99\u91cc\u7701"
@@ -310,7 +328,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1614895002,
+    "wof:lastmodified":1690938490,
     "wof:name":"Ph\u00f4ngsali",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/63/85673463.geojson
+++ b/data/856/734/63/85673463.geojson
@@ -36,8 +36,14 @@
     "name:ben_x_preferred":[
         "\u09ac\u09b2\u09bf\u0996\u09be\u09ae\u09b8\u09be\u0987 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u09ac\u09cb\u09b2\u09bf\u0996\u09be\u09ae\u09b8\u09be\u0987 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
     "name:ceb_x_preferred":[
         "Bolikhamxai"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Bolikhamsai"
     ],
     "name:dan_x_preferred":[
         "Bolikhamsai Province"
@@ -68,10 +74,14 @@
         "Borikhamxay"
     ],
     "name:fra_x_variant":[
-        "Province de Borikhamxay"
+        "Province de Borikhamxay",
+        "Bolikhamxai"
     ],
     "name:guj_x_preferred":[
         "\u0aac\u0acb\u0ab2\u0abf\u0a96\u0abe\u0a82\u0ab8\u0abe\u0a88 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d1\u05d5\u05dc\u05d9\u05e7\u05de\u05e1\u05d0\u05d9"
     ],
     "name:hin_x_preferred":[
         "\u092c\u094b\u0932\u093f\u0916\u092e\u0938\u093e\u0907 \u092a\u094d\u0930\u093e\u0928\u094d\u0924"
@@ -99,6 +109,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubcfc\ub9ac\uce84\uc0ac\uc774 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ubcfc\ub9ac\uce84\uc0ac\uc774\uc8fc"
     ],
     "name:lao_x_preferred":[
         "\u0ec1\u0e82\u0ea7\u0e87\u0e9a\u0ecd\u0ea5\u0eb4\u0e84\u0ecd\u0eb2\u0ec4\u0e8a"
@@ -136,8 +149,14 @@
     "name:rus_x_preferred":[
         "\u0411\u043e\u0440\u0438\u043a\u0445\u0430\u043c\u0441\u0430\u0439"
     ],
+    "name:rus_x_variant":[
+        "\u0411\u043e\u043b\u0438\u043a\u0445\u0430\u043c\u0441\u0430\u0439"
+    ],
     "name:sin_x_preferred":[
         "\u0db6\u0ddc\u0dbd\u0dd2\u0d9a\u0db8\u0dc3\u0dcf\u0dba\u0dd2 \u0db4\u0dc5\u0dcf\u0dad"
+    ],
+    "name:som_x_preferred":[
+        "Bolikhamxai"
     ],
     "name:spa_x_preferred":[
         "Bolikhamxai"
@@ -175,6 +194,12 @@
     ],
     "name:war_x_preferred":[
         "Bolikhamsai"
+    ],
+    "name:wuu_x_preferred":[
+        "\u6ce2\u91cc\u574e\u585e\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u535a\u5229\u6562\u8cfd\u7701"
     ],
     "name:zho_x_preferred":[
         "\u535a\u5229\u574e\u8d5b\u7701"
@@ -286,7 +311,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1614895004,
+    "wof:lastmodified":1690938495,
     "wof:name":"Borikhamxai",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/67/85673467.geojson
+++ b/data/856/734/67/85673467.geojson
@@ -39,11 +39,20 @@
     "name:ben_x_preferred":[
         "\u0996\u09be\u09ae\u09ae\u09c1\u09af\u09bc\u09be\u09a8 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u0996\u09be\u09ae\u09cd\u09ae\u09c1\u09af\u09bc\u09be\u09a8 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
     "name:bul_x_preferred":[
         "\u041a\u0445\u0430\u043c\u043e\u0443\u0430\u043d"
     ],
+    "name:cat_x_preferred":[
+        "Khammouan"
+    ],
     "name:ceb_x_preferred":[
         "Khammouan"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Khammouane"
     ],
     "name:dan_x_preferred":[
         "Khammouane Province"
@@ -73,7 +82,8 @@
         "Khammouane"
     ],
     "name:fra_x_variant":[
-        "Province de Khammouane"
+        "Province de Khammouane",
+        "Khammouan"
     ],
     "name:guj_x_preferred":[
         "\u0a96\u0aae\u0abe\u0a89\u0aa8\u0ac7 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
@@ -107,6 +117,9 @@
     ],
     "name:kor_x_preferred":[
         "\uce84\ubb34\uc548 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uce84\ubb34\uc548\uc8fc"
     ],
     "name:lao_x_preferred":[
         "\u0ec1\u0e82\u0ea7\u0e87\u0e84\u0eb3\u0ea1\u0ec8\u0ea7\u0e99"
@@ -144,6 +157,9 @@
     "name:sin_x_preferred":[
         "\u0d9b\u0d82\u0db8\u0dde\u0db1\u0dd9 \u0db4\u0dc5\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "Khammouan"
+    ],
     "name:spa_x_preferred":[
         "Provincia de Khammouan"
     ],
@@ -180,6 +196,12 @@
     ],
     "name:war_x_preferred":[
         "Khammuan"
+    ],
+    "name:wuu_x_preferred":[
+        "\u7518\u8499\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u7518\u8499\u7701"
     ],
     "name:zho_x_preferred":[
         "\u7518\u8499\u7701"
@@ -308,7 +330,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1636495630,
+    "wof:lastmodified":1690938492,
     "wof:name":"Khammouan",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/69/85673469.geojson
+++ b/data/856/734/69/85673469.geojson
@@ -42,17 +42,26 @@
     "name:ben_x_preferred":[
         "\u0986\u09a4\u09cd\u09a4\u09be\u09aa\u09bf\u0989 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u0986\u09a4\u09cd\u09a4\u09be\u09aa\u09c7\u0989 \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
+    ],
     "name:cat_x_preferred":[
         "prov\u00edncia d'Attapeu"
     ],
     "name:ceb_x_preferred":[
         "Attapu"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Attapeu"
+    ],
     "name:dan_x_preferred":[
         "Attapeu Province"
     ],
     "name:deu_x_preferred":[
         "Provinz Attapeu"
+    ],
+    "name:diq_x_preferred":[
+        "Attapeu"
     ],
     "name:ell_x_preferred":[
         "\u0391\u03c4\u03c4\u03ac\u03c0\u03bf\u03c5"
@@ -79,10 +88,14 @@
         "Attapeu"
     ],
     "name:fra_x_variant":[
-        "Province d'Attapeu"
+        "Province d'Attapeu",
+        "Attapu"
     ],
     "name:guj_x_preferred":[
         "\u0a85\u0a9f\u0ac7\u0aaa\u0ac7\u0a89 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d0\u05d8\u05d5\u05e4\u05d5"
     ],
     "name:hin_x_preferred":[
         "\u0905\u0924\u094d\u0924\u093e\u092a\u094d\u092f\u0941 \u092a\u094d\u0930\u093e\u0928\u094d\u0924"
@@ -104,6 +117,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0c85\u0c9f\u0cbe\u0caa\u0cc2 \u0caa\u0ccd\u0cb0\u0cbe\u0c82\u0ca4\u0ccd\u0caf"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d0\u10e2\u10d0\u10de\u10d4\u10e3\u10e1 \u10de\u10e0\u10dd\u10d5\u10d8\u10dc\u10ea\u10d8\u10d0"
     ],
     "name:khm_x_preferred":[
         "\u1781\u17d2\u179c\u17c2\u1784\u17a2\u17b6\u1785\u1798\u17cd\u1780\u17d2\u179a\u1796\u17be"
@@ -151,6 +167,9 @@
     "name:sin_x_preferred":[
         "\u0d87\u0da7\u0dda\u0db4\u0dd6 \u0db4\u0dc5\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "Attapu"
+    ],
     "name:spa_x_preferred":[
         "Provincia de Attapeu"
     ],
@@ -186,6 +205,12 @@
     ],
     "name:war_x_preferred":[
         "Attapeu"
+    ],
+    "name:wuu_x_preferred":[
+        "\u963f\u901f\u5761\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u963f\u901f\u5761\u7701"
     ],
     "name:zho_x_preferred":[
         "\u963f\u901f\u5761\u7701"
@@ -311,7 +336,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1614895002,
+    "wof:lastmodified":1690938491,
     "wof:name":"Attapeu",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/73/85673473.geojson
+++ b/data/856/734/73/85673473.geojson
@@ -42,10 +42,16 @@
     "name:ceb_x_preferred":[
         "Khou\u00e8ng X\u00e9kong"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Sekong"
+    ],
     "name:dan_x_preferred":[
         "Sekong Province"
     ],
     "name:deu_x_preferred":[
+        "Sekong"
+    ],
+    "name:diq_x_preferred":[
         "Sekong"
     ],
     "name:ell_x_preferred":[
@@ -66,14 +72,21 @@
     "name:fin_x_preferred":[
         "Sekongin l\u00e4\u00e4ni"
     ],
+    "name:fin_x_variant":[
+        "Xekong"
+    ],
     "name:fra_x_preferred":[
         "S\u00e9kong"
     ],
     "name:fra_x_variant":[
-        "Province de S\u00e9kong"
+        "Province de S\u00e9kong",
+        "X\u00e9kong"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0a95\u0acb\u0a82\u0a97 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6\u05e1\u05e7\u05d5\u05e0\u05d2"
     ],
     "name:hin_x_preferred":[
         "\u0938\u0947\u0915\u094b\u0902\u0917 \u092a\u094d\u0930\u093e\u0928\u094d\u0924"
@@ -99,8 +112,14 @@
     "name:kan_x_preferred":[
         "\u0cb8\u0cc6\u0c95\u0cca\u0c82\u0c97\u0ccd \u0caa\u0ccd\u0cb0\u0cbe\u0c82\u0ca4\u0ccd\u0caf"
     ],
+    "name:khm_x_preferred":[
+        "\u1781\u17c1\u178f\u17d2\u178f\u200b\u179f\u17d2\u179a\u17c2\u1782\u1784\u17d2\u1782"
+    ],
     "name:kor_x_preferred":[
         "\uc138\ucf69 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc138\ucf69\uc8fc"
     ],
     "name:lao_x_preferred":[
         "\u0ec1\u0e82\u0ea7\u0e87\u0ec0\u0e8a\u0e81\u0ead\u0e87"
@@ -138,6 +157,9 @@
     "name:sin_x_preferred":[
         "\u0dc3\u0dda\u0d9a\u0ddc\u0db1\u0dca\u0d9c\u0dca \u0db4\u0dc5\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "X\u00e9kong"
+    ],
     "name:spa_x_preferred":[
         "Sekong"
     ],
@@ -173,6 +195,12 @@
     ],
     "name:war_x_preferred":[
         "Sekong"
+    ],
+    "name:wuu_x_preferred":[
+        "\u585e\u516c\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u585e\u516c\u7701"
     ],
     "name:zho_x_preferred":[
         "\u585e\u516c\u7701"
@@ -298,7 +326,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1614895003,
+    "wof:lastmodified":1690938493,
     "wof:name":"X\u00e9kong",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/890/415/487/890415487.geojson
+++ b/data/890/415/487/890415487.geojson
@@ -19,11 +19,35 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:arg_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:ast_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:bos_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:cat_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
     "name:ceb_x_preferred":[
         "Muang Ph\u00f4n-H\u00f4ng"
     ],
+    "name:ceb_x_variant":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:ces_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:dan_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
     "name:deu_x_preferred":[
         "Muang Ph\u00f4n-H\u00f4ng"
+    ],
+    "name:deu_x_variant":[
+        "Ph\u014dnh\u014dng"
     ],
     "name:ell_x_preferred":[
         "\u039c\u03bf\u03c5\u03ac\u03bd\u03b3\u03ba \u03a6\u03bf\u03bd-\u03a7\u03bf\u03bd\u03b3\u03ba"
@@ -31,23 +55,134 @@
     "name:eng_x_preferred":[
         "Muang Phon-Hong"
     ],
+    "name:eng_x_variant":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:epo_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:est_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:eus_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:fin_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
     "name:fra_x_preferred":[
         "Phon Hong"
+    ],
+    "name:fra_x_variant":[
+        "Ph\u00f4nh\u00f4ng"
+    ],
+    "name:fry_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:glg_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:gsw_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:hrv_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:hun_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:ind_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:isl_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:ita_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30dd\u30f3\u30db\u30fc\u30f3\u90e1"
+    ],
+    "name:khm_x_preferred":[
+        "\u1798\u17bf\u1784\u1795\u17bc\u1793\u17a0\u17bc\u1784"
+    ],
+    "name:lao_x_preferred":[
+        "\u0ec2\u0e9e\u0e99\u0ec2\u0eae\u0e87"
+    ],
+    "name:lat_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:lav_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:lim_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:ltz_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:min_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:msa_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:nds_x_preferred":[
+        "Ph\u014dnh\u014dng"
     ],
     "name:nld_x_preferred":[
         "Phon Hong"
     ],
+    "name:nld_x_variant":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:nno_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:nob_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
     "name:pol_x_preferred":[
         "Muang Ph\u00f4n-H\u00f4ng"
+    ],
+    "name:pol_x_variant":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:por_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:ron_x_preferred":[
+        "Ph\u014dnh\u014dng"
     ],
     "name:rus_x_preferred":[
         "\u041f\u0445\u043e\u043d\u0445\u043e\u043d\u0433"
     ],
+    "name:sco_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:slk_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:slv_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:spa_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:sqi_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
     "name:swe_x_preferred":[
         "Muang Ph\u00f4n-H\u00f4ng"
     ],
+    "name:swe_x_variant":[
+        "Ph\u014dnh\u014dng"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e21\u0e37\u0e2d\u0e07\u0e42\u0e1e\u0e19\u0e42\u0e2e\u0e07"
+    ],
+    "name:tur_x_preferred":[
+        "Ph\u014dnh\u014dng"
     ],
     "name:und_x_variant":[
         "Ban Phong Hong"
@@ -55,8 +190,17 @@
     "name:vie_x_preferred":[
         "Phonhong"
     ],
+    "name:vie_x_variant":[
+        "Ph\u014dnh\u014dng"
+    ],
     "name:war_x_preferred":[
         "Muang Ph\u00f4n-H\u00f4ng"
+    ],
+    "name:yor_x_preferred":[
+        "Ph\u014dnh\u014dng"
+    ],
+    "name:zea_x_preferred":[
+        "Ph\u014dnh\u014dng"
     ],
     "name:zho_x_preferred":[
         "\u5df4\u8272"
@@ -97,7 +241,7 @@
         }
     ],
     "wof:id":890415487,
-    "wof:lastmodified":1566593357,
+    "wof:lastmodified":1690938504,
     "wof:name":"Muang Ph\u00f4n-H\u00f4ng",
     "wof:parent_id":1092028631,
     "wof:placetype":"locality",

--- a/data/890/420/439/890420439.geojson
+++ b/data/890/420/439/890420439.geojson
@@ -22,11 +22,20 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0627\u0646\u062c \u0625\u0643\u0633\u0627\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u0627\u0646\u062c \u0627\u0643\u0633\u0627\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Muang Xay"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09c1\u09af\u09bc\u09be\u0982 \u09af\u09be\u0987"
     ],
     "name:ceb_x_preferred":[
         "Muang Xay"
+    ],
+    "name:ceb_x_variant":[
+        "M\u01b0\u0304ang Sai"
     ],
     "name:dan_x_preferred":[
         "Muang Xay"
@@ -40,6 +49,9 @@
     "name:eng_x_preferred":[
         "Muang Xay"
     ],
+    "name:eng_x_variant":[
+        "M\u01b0\u0304ang Sai"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0648\u0627\u0646\u06af \u0634\u0627\u06cc"
     ],
@@ -49,8 +61,14 @@
     "name:fra_x_preferred":[
         "Muang Xay"
     ],
+    "name:fra_x_variant":[
+        "Muang-Xai"
+    ],
     "name:guj_x_preferred":[
         "\u0aae\u0acd\u0aaf\u0ac1\u0a86\u0a82\u0a97 \u0a9d\u0ac7\u0aaf"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d5\u05d0\u05e0\u05d2 \u05e9\u05d9"
     ],
     "name:hin_x_preferred":[
         "\u092e\u0941\u0906\u0902\u0917 \u091c\u093e\u092f\u0947"
@@ -70,8 +88,14 @@
     "name:kat_x_preferred":[
         "\u10e1\u10d0\u10d8"
     ],
+    "name:khm_x_preferred":[
+        "\u1798\u17bf\u1784\u1787\u17d0\u1799"
+    ],
     "name:kor_x_preferred":[
         "\ubb34\uc559\uc2f8\uc774"
+    ],
+    "name:krj_x_preferred":[
+        "M\u01b0\u0304ang Sai"
     ],
     "name:lav_x_preferred":[
         "Muangsaja"
@@ -84,6 +108,9 @@
     ],
     "name:msa_x_preferred":[
         "Muang Xay"
+    ],
+    "name:mya_x_preferred":[
+        "\u1019\u102d\u102f\u1038\u1006\u102d\u102f\u1004\u103a"
     ],
     "name:nld_x_preferred":[
         "Muang Xay"
@@ -109,8 +136,14 @@
     "name:spa_x_preferred":[
         "Muang Xay"
     ],
+    "name:spa_x_variant":[
+        "M\u01b0\u0304ang Sai"
+    ],
     "name:swe_x_preferred":[
         "Muang Xay"
+    ],
+    "name:swe_x_variant":[
+        "M\u01b0\u0304ang Sai"
     ],
     "name:tam_x_preferred":[
         "\u0bae\u0bbf\u0baf\u0bc2\u0b86\u0b99\u0bcd\u0b9a\u0bc6"
@@ -138,6 +171,9 @@
     ],
     "name:war_x_preferred":[
         "Muang Xai"
+    ],
+    "name:war_x_variant":[
+        "M\u01b0\u0304ang Sai"
     ],
     "name:zho_x_preferred":[
         "\u8292\u8d5b"
@@ -177,7 +213,7 @@
         }
     ],
     "wof:id":890420439,
-    "wof:lastmodified":1566593358,
+    "wof:lastmodified":1690938505,
     "wof:name":"Muang Xay",
     "wof:parent_id":1092029739,
     "wof:placetype":"locality",

--- a/data/890/433/781/890433781.geojson
+++ b/data/890/433/781/890433781.geojson
@@ -22,20 +22,38 @@
     "name:ara_x_preferred":[
         "\u0641\u0648\u0646\u063a\u0633\u0627\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0648\u0646\u062c\u0633\u0627\u0644\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:ben_x_preferred":[
         "\u09ab\u09cb\u0982\u09b8\u09be\u09b2\u09bf"
     ],
     "name:ceb_x_preferred":[
         "Ph\u00f4ngsali"
     ],
+    "name:ceb_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:ces_x_preferred":[
         "Phongsali"
+    ],
+    "name:ces_x_variant":[
+        "Phongs\u0101l\u012b"
     ],
     "name:dan_x_preferred":[
         "Phongsali"
     ],
+    "name:dan_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:deu_x_preferred":[
         "Phongsali"
+    ],
+    "name:deu_x_variant":[
+        "Phongs\u0101l\u012b"
     ],
     "name:ell_x_preferred":[
         "\u03a0\u03bf\u03bd\u03b3\u03ba\u03c3\u03ac\u03bb\u03b9"
@@ -43,8 +61,14 @@
     "name:eng_x_preferred":[
         "Phongsali"
     ],
+    "name:eng_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:epo_x_preferred":[
         "Phongsali"
+    ],
+    "name:epo_x_variant":[
+        "Phongs\u0101l\u012b"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0648\u0646\u06af\u0633\u0627\u0644\u06cc"
@@ -52,11 +76,20 @@
     "name:fin_x_preferred":[
         "Ph\u00f4ngsali"
     ],
+    "name:fin_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:fra_x_preferred":[
         "Phongsali"
     ],
+    "name:fra_x_variant":[
+        "Ph\u00f4ngsali"
+    ],
     "name:guj_x_preferred":[
         "\u0aab\u0acb\u0a82\u0a97\u0acd\u0ab8\u0ab2\u0ac0"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e4\u05d5\u05e0\u05d2\u05e1\u05d0\u05dc\u05d9"
     ],
     "name:hin_x_preferred":[
         "\u092b\u094b\u0902\u0917\u094d\u0938\u0932\u093f"
@@ -64,8 +97,14 @@
     "name:ind_x_preferred":[
         "Phongsali"
     ],
+    "name:ind_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:ita_x_preferred":[
         "Phongsali"
+    ],
+    "name:ita_x_variant":[
+        "Phongs\u0101l\u012b"
     ],
     "name:jpn_x_preferred":[
         "\u30dd\u30f3\u30b5\u30fc\u30ea\u30fc\u90e1"
@@ -79,6 +118,9 @@
     "name:kor_x_preferred":[
         "\ud401\uc0b4\ub9ac"
     ],
+    "name:krj_x_preferred":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:lav_x_preferred":[
         "Fongsali"
     ],
@@ -91,17 +133,32 @@
     "name:msa_x_preferred":[
         "Phongsali"
     ],
+    "name:msa_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:nld_x_preferred":[
         "Phongsali"
+    ],
+    "name:nld_x_variant":[
+        "Phongs\u0101l\u012b"
     ],
     "name:nob_x_preferred":[
         "Phongsali"
     ],
+    "name:nob_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:pol_x_preferred":[
         "Ph\u00f4ngsali"
     ],
+    "name:pol_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:por_x_preferred":[
         "Phongsali"
+    ],
+    "name:por_x_variant":[
+        "Phongs\u0101l\u012b"
     ],
     "name:rus_x_preferred":[
         "\u041f\u0445\u043e\u043d\u0433\u0441\u0430\u043b\u0438"
@@ -112,8 +169,14 @@
     "name:spa_x_preferred":[
         "Phongsali"
     ],
+    "name:spa_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:swe_x_preferred":[
         "Phongsali"
+    ],
+    "name:swe_x_variant":[
+        "Phongs\u0101l\u012b"
     ],
     "name:tam_x_preferred":[
         "\u0baa\u0bbe\u0b99\u0bcd\u0b9a\u0bbe\u0bb2\u0bbf"
@@ -127,6 +190,9 @@
     "name:tur_x_preferred":[
         "Phongsali"
     ],
+    "name:tur_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:ukr_x_preferred":[
         "\u041f\u0445\u043e\u043d\u0433\u0441\u0430\u043b\u0456"
     ],
@@ -139,8 +205,14 @@
     "name:vie_x_preferred":[
         "Phongsaly"
     ],
+    "name:vie_x_variant":[
+        "Phongs\u0101l\u012b"
+    ],
     "name:war_x_preferred":[
         "Phongsali"
+    ],
+    "name:war_x_variant":[
+        "Phongs\u0101l\u012b"
     ],
     "name:zho_x_preferred":[
         "\u8c50\u6c99\u91cc"
@@ -272,7 +344,7 @@
         }
     ],
     "wof:id":890433781,
-    "wof:lastmodified":1566593359,
+    "wof:lastmodified":1690938506,
     "wof:name":"Ph\u00f4ngsali",
     "wof:parent_id":1092026617,
     "wof:placetype":"locality",

--- a/data/890/433/787/890433787.geojson
+++ b/data/890/433/787/890433787.geojson
@@ -22,11 +22,23 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u064a\u0630\u064a\u0628\u0648\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u064a\u0630\u064a\u0628\u0648\u0644\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Sainyabuli"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09bf\u09a8\u09be\u09af\u09bc\u09be\u09ac\u09c1\u09b2\u09bf"
     ],
     "name:ceb_x_preferred":[
         "Sainyabuli"
+    ],
+    "name:ceb_x_variant":[
+        "Sainyab\u016bl\u012b"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0633\u0627\u06cc\u0646\u0627\u0628\u0648\u0644\u06cc"
     ],
     "name:dan_x_preferred":[
         "Sainyabuli"
@@ -51,7 +63,8 @@
     "name:eng_x_variant":[
         "Sainyabuli",
         "Xayaburi",
-        "Xayaboury"
+        "Xayaboury",
+        "Sainyab\u016bl\u012b"
     ],
     "name:epo_x_preferred":[
         "Sainjabuli"
@@ -65,14 +78,23 @@
     "name:fra_x_preferred":[
         "Sainyabuli"
     ],
+    "name:fra_x_variant":[
+        "Xaignabouli"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac8\u0aa8\u0acd\u0aaf\u0abe\u0aac\u0ac1\u0ab2\u0ac0"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d0\u05d9\u05e0\u05d1\u05d5\u05dc\u05d9"
     ],
     "name:hin_x_preferred":[
         "\u0938\u0948\u0928\u094d\u092f\u0905\u092c\u0932\u0940"
     ],
     "name:ind_x_preferred":[
         "Xaignabouli"
+    ],
+    "name:ind_x_variant":[
+        "Sainyab\u016bl\u012b"
     ],
     "name:ita_x_preferred":[
         "Sainyabuli"
@@ -86,8 +108,14 @@
     "name:kat_x_preferred":[
         "\u10e1\u10d0\u10d8\u10dc\u10d8\u10d0\u10d1\u10e3\u10da\u10d8"
     ],
+    "name:khm_x_preferred":[
+        "\u1787\u17d0\u1799\u1794\u17bb\u179a\u17b8"
+    ],
     "name:kor_x_preferred":[
         "\uc0ac\uc778\ubd88\ub9ac"
+    ],
+    "name:lao_x_preferred":[
+        "\u0ec0\u0ea1\u0eb7\u0ead\u0e87\u0ec4\u0e8a\u0e8d\u0eb0\u0e9a\u0eb9\u0ea5\u0eb5"
     ],
     "name:lav_x_preferred":[
         "Sai\u0146ab\u016bl\u012b"
@@ -125,6 +153,9 @@
     "name:spa_x_preferred":[
         "Sainyabuli"
     ],
+    "name:spa_x_variant":[
+        "Sainyab\u016bl\u012b"
+    ],
     "name:swe_x_preferred":[
         "Sainyabuli"
     ],
@@ -133,6 +164,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c38\u0c48\u0c28\u0c4d\u0c2f \u0c05\u0c2c\u0c32\u0c3f"
+    ],
+    "name:tgl_x_preferred":[
+        "Sainyab\u016bl\u012b"
     ],
     "name:tha_x_preferred":[
         "\u0e44\u0e0a\u0e22\u0e1a\u0e38\u0e23\u0e35"
@@ -154,6 +188,9 @@
     ],
     "name:war_x_preferred":[
         "Sainyabuli"
+    ],
+    "name:war_x_variant":[
+        "Sainyab\u016bl\u012b"
     ],
     "name:zho_x_preferred":[
         "\u6c99\u8036\u6b66\u91cc"
@@ -285,7 +322,7 @@
         }
     ],
     "wof:id":890433787,
-    "wof:lastmodified":1566593359,
+    "wof:lastmodified":1690938506,
     "wof:name":"Xaignabouli",
     "wof:parent_id":1092030249,
     "wof:placetype":"locality",

--- a/data/890/433/789/890433789.geojson
+++ b/data/890/433/789/890433789.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0646 \u0647\u0648\u0643\u0633\u0649"
     ],
+    "name:ast_x_preferred":[
+        "Ban Houayxay"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u09a8 \u09b9\u09cc\u09df\u09be\u0995\u09cd\u09b8\u09c7"
+    ],
+    "name:ceb_x_preferred":[
+        "H\u016bais\u0101i"
     ],
     "name:ces_x_preferred":[
         "Huay Xai"
@@ -37,6 +43,9 @@
     "name:eng_x_preferred":[
         "Ban Houayxay"
     ],
+    "name:eng_x_variant":[
+        "H\u016bais\u0101i"
+    ],
     "name:epo_x_preferred":[
         "Ban Huajsai"
     ],
@@ -45,6 +54,9 @@
     ],
     "name:fra_x_preferred":[
         "Houei Sai"
+    ],
+    "name:fra_x_variant":[
+        "Houayxay"
     ],
     "name:heb_x_preferred":[
         "\u05d1\u05d0\u05df \u05d4\u05d5\u05d0\u05e7\u05e1\u05d0\u05d9"
@@ -67,6 +79,12 @@
     "name:kat_x_preferred":[
         "\u10f0\u10e3\u10d0\u10d8\u10e1\u10d0\u10d8"
     ],
+    "name:khm_x_preferred":[
+        "\u17a0\u17bd\u1799\u179f\u17b6\u1799"
+    ],
+    "name:kor_x_preferred":[
+        "\ubc18\ud6c4\uc548\uc0ac\uc774"
+    ],
     "name:lao_x_preferred":[
         "\u0eab\u0ec9\u0ea7\u0e8d\u0e8a\u0eb2\u0e8d"
     ],
@@ -88,6 +106,9 @@
     "name:spa_x_preferred":[
         "Ban Houayxay"
     ],
+    "name:spa_x_variant":[
+        "H\u016bais\u0101i"
+    ],
     "name:swe_x_preferred":[
         "Ban Houayxay"
     ],
@@ -96,6 +117,9 @@
     ],
     "name:tur_x_preferred":[
         "Ban Houayxay"
+    ],
+    "name:tur_x_variant":[
+        "Houayxay"
     ],
     "name:ukr_x_preferred":[
         "\u0411\u0430\u043d \u0425\u0443\u0430\u0439\u0441\u0430\u0439"
@@ -111,6 +135,9 @@
     ],
     "name:war_x_preferred":[
         "Ban Houayxay"
+    ],
+    "name:war_x_variant":[
+        "H\u016bais\u0101i"
     ],
     "name:zho_x_preferred":[
         "\u6703\u6652"
@@ -251,7 +278,7 @@
         }
     ],
     "wof:id":890433789,
-    "wof:lastmodified":1636495635,
+    "wof:lastmodified":1690938506,
     "wof:name":"Ban Houayxay",
     "wof:parent_id":1092031167,
     "wof:placetype":"locality",

--- a/data/890/433/791/890433791.geojson
+++ b/data/890/433/791/890433791.geojson
@@ -22,11 +22,23 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0643\u0633\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0643\u0633\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Pakxan"
+    ],
+    "name:bel_x_preferred":[
+        "\u041f\u0430\u043a\u0441\u0430\u043d"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09be\u0995\u09cd\u09b8\u09be\u09a8"
     ],
     "name:ceb_x_preferred":[
         "Muang Pakxan"
+    ],
+    "name:ceb_x_variant":[
+        "P\u0101ksan"
     ],
     "name:dan_x_preferred":[
         "Pakxan"
@@ -52,8 +64,14 @@
     "name:fra_x_preferred":[
         "Paksane"
     ],
+    "name:fra_x_variant":[
+        "Pakxan"
+    ],
     "name:guj_x_preferred":[
         "\u0aaa\u0a95\u0acd\u0ab8\u0abe\u0aa8"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e4\u05e7\u05e1\u05df"
     ],
     "name:hin_x_preferred":[
         "\u092a\u0915\u094d\u0938\u093e\u0928"
@@ -72,6 +90,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10de\u10d0\u10e5\u10e1\u10d0\u10dc\u10d8"
+    ],
+    "name:khm_x_preferred":[
+        "\u1794\u17c9\u17b6\u1780\u179f\u17b6\u1793\u17cb"
     ],
     "name:kor_x_preferred":[
         "\ud30d\uc0b0"
@@ -109,6 +130,9 @@
     "name:spa_x_preferred":[
         "Pakxan"
     ],
+    "name:spa_x_variant":[
+        "P\u0101ksan"
+    ],
     "name:swe_x_preferred":[
         "Pakxan"
     ],
@@ -135,6 +159,9 @@
     ],
     "name:war_x_preferred":[
         "Paksan"
+    ],
+    "name:war_x_variant":[
+        "P\u0101ksan"
     ],
     "name:zho_x_preferred":[
         "\u5317\u6c55"
@@ -170,7 +197,7 @@
         }
     ],
     "wof:id":890433791,
-    "wof:lastmodified":1566593358,
+    "wof:lastmodified":1690938505,
     "wof:name":"Muang Pakxan",
     "wof:parent_id":1092028315,
     "wof:placetype":"locality",

--- a/data/890/435/715/890435715.geojson
+++ b/data/890/435/715/890435715.geojson
@@ -22,14 +22,29 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0644\u0627\u0641\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0644\u0627\u0641\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "S\u0101lavan"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09cd\u09af\u09be\u09b2\u09be\u09ad\u09be\u09a8"
+    ],
+    "name:ceb_x_preferred":[
+        "S\u0101lavan"
     ],
     "name:dan_x_preferred":[
         "Salavan"
     ],
+    "name:dan_x_variant":[
+        "S\u0101lavan"
+    ],
     "name:deu_x_preferred":[
         "Salavan"
+    ],
+    "name:deu_x_variant":[
+        "S\u0101lavan"
     ],
     "name:ell_x_preferred":[
         "\u03a3\u03b1\u03bb\u03b1\u03b2\u03ac\u03bd"
@@ -37,14 +52,23 @@
     "name:eng_x_preferred":[
         "Salavan"
     ],
+    "name:eng_x_variant":[
+        "S\u0101lavan"
+    ],
     "name:epo_x_preferred":[
         "Salavan"
+    ],
+    "name:epo_x_variant":[
+        "S\u0101lavan"
     ],
     "name:fas_x_preferred":[
         "\u0633\u0627\u0644\u0627\u0648\u0627\u0646"
     ],
     "name:fin_x_preferred":[
         "Salavan"
+    ],
+    "name:fin_x_variant":[
+        "S\u0101lavan"
     ],
     "name:fra_x_preferred":[
         "Salavan"
@@ -61,8 +85,14 @@
     "name:ind_x_preferred":[
         "Salavan"
     ],
+    "name:ind_x_variant":[
+        "S\u0101lavan"
+    ],
     "name:ita_x_preferred":[
         "Salavan"
+    ],
+    "name:ita_x_variant":[
+        "S\u0101lavan"
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30fc\u30e9\u30ef\u30f3"
@@ -72,6 +102,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10e1\u10d0\u10e0\u10d0\u10d5\u10d0\u10dc\u10d8"
+    ],
+    "name:khm_x_preferred":[
+        "\u179f\u17b6\u17a1\u17b6\u179c\u17c9\u17b6\u1793\u17cb"
     ],
     "name:kor_x_preferred":[
         "\uc0ac\ub77c\ubc18"
@@ -91,17 +124,29 @@
     "name:msa_x_preferred":[
         "Salavan"
     ],
+    "name:msa_x_variant":[
+        "S\u0101lavan"
+    ],
     "name:nld_x_preferred":[
         "Salavan"
     ],
+    "name:nld_x_variant":[
+        "S\u0101lavan"
+    ],
     "name:nob_x_preferred":[
         "Salavan"
+    ],
+    "name:nob_x_variant":[
+        "S\u0101lavan"
     ],
     "name:pol_x_preferred":[
         "Saravane"
     ],
     "name:por_x_preferred":[
         "Salavan"
+    ],
+    "name:por_x_variant":[
+        "S\u0101lavan"
     ],
     "name:rus_x_preferred":[
         "\u0421\u0430\u0440\u0430\u0432\u0430\u043d"
@@ -112,8 +157,14 @@
     "name:spa_x_preferred":[
         "Salavan"
     ],
+    "name:spa_x_variant":[
+        "S\u0101lavan"
+    ],
     "name:swe_x_preferred":[
         "Salavan"
+    ],
+    "name:swe_x_variant":[
+        "S\u0101lavan"
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bbe\u0bb2\u0bcd\u0bb5\u0ba9\u0bcd"
@@ -127,8 +178,14 @@
     "name:tur_x_preferred":[
         "Salavan"
     ],
+    "name:tur_x_variant":[
+        "S\u0101lavan"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0430\u043b\u0430\u0432\u0430\u043d"
+    ],
+    "name:ukr_x_variant":[
+        "\u0421\u0430\u0440\u0430\u0432\u0430\u043d"
     ],
     "name:und_x_variant":[
         "Muang Saravane"
@@ -141,6 +198,9 @@
     ],
     "name:war_x_preferred":[
         "Salavan"
+    ],
+    "name:war_x_variant":[
+        "S\u0101lavan"
     ],
     "name:zho_x_preferred":[
         "\u6c99\u62c9\u7063"
@@ -270,7 +330,7 @@
         }
     ],
     "wof:id":890435715,
-    "wof:lastmodified":1566593359,
+    "wof:lastmodified":1690938507,
     "wof:name":"Salavan",
     "wof:parent_id":1092028911,
     "wof:placetype":"locality",

--- a/data/890/439/927/890439927.geojson
+++ b/data/890/439/927/890439927.geojson
@@ -22,11 +22,20 @@
     "name:ara_x_preferred":[
         "\u062b\u0627\u0643\u064a\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u062b\u0627\u0643\u064a\u0643"
+    ],
+    "name:ast_x_preferred":[
+        "Thakhek"
+    ],
     "name:ben_x_preferred":[
         "\u09a5\u09be\u0996\u09c7\u0995"
     ],
     "name:bul_x_preferred":[
         "\u0422\u0430\u043a\u0435\u043a"
+    ],
+    "name:ceb_x_preferred":[
+        "Th\u0101kh\u01e3k"
     ],
     "name:ces_x_preferred":[
         "Thakhek"
@@ -43,6 +52,9 @@
     "name:eng_x_preferred":[
         "Thakhek"
     ],
+    "name:eng_x_variant":[
+        "Thakh\u00e8k"
+    ],
     "name:epo_x_preferred":[
         "Tha\u0125ek"
     ],
@@ -54,6 +66,9 @@
     ],
     "name:fra_x_preferred":[
         "Thakhek"
+    ],
+    "name:fra_x_variant":[
+        "Thakh\u00e8k"
     ],
     "name:guj_x_preferred":[
         "\u0aa5\u0abe\u0a96\u0ac7\u0a95"
@@ -78,6 +93,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10d7\u10d0\u10d9\u10d4\u10d9\u10d8"
+    ],
+    "name:khm_x_preferred":[
+        "\u1790\u17b6\u1781\u17c2\u1780"
     ],
     "name:kor_x_preferred":[
         "\ud0c0\ucf01"
@@ -115,8 +133,14 @@
     "name:sin_x_preferred":[
         "\u0dad\u0dcf\u0d9a\u0dd9\u0d9a\u0dca"
     ],
+    "name:spa_x_preferred":[
+        "Th\u0101kh\u01e3k"
+    ],
     "name:swe_x_preferred":[
         "Thakhek"
+    ],
+    "name:swe_x_variant":[
+        "Th\u0101kh\u01e3k"
     ],
     "name:tam_x_preferred":[
         "\u0b9f\u0bbe\u0b95\u0bcd\u0b95\u0bc7\u0b95\u0bcd"
@@ -144,6 +168,9 @@
     ],
     "name:war_x_preferred":[
         "Thakhek"
+    ],
+    "name:war_x_variant":[
+        "Th\u0101kh\u01e3k"
     ],
     "name:zho_x_preferred":[
         "\u4ed6\u66f2"
@@ -275,7 +302,7 @@
         }
     ],
     "wof:id":890439927,
-    "wof:lastmodified":1566593357,
+    "wof:lastmodified":1690938504,
     "wof:name":"Thakh\u00e8k",
     "wof:parent_id":1092030293,
     "wof:placetype":"locality",

--- a/data/890/440/015/890440015.geojson
+++ b/data/890/440/015/890440015.geojson
@@ -25,14 +25,26 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0643\u0633\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0643\u0633\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Pakse"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09be\u0995\u09b8\u09c7"
     ],
     "name:bul_x_preferred":[
         "\u041f\u0430\u043a\u0441\u0435"
     ],
+    "name:cat_x_preferred":[
+        "Pakse"
+    ],
     "name:ceb_x_preferred":[
         "Pakx\u00e9"
+    ],
+    "name:ceb_x_variant":[
+        "P\u0101ks\u0113"
     ],
     "name:ces_x_preferred":[
         "Pakse"
@@ -55,6 +67,9 @@
     "name:eng_x_preferred":[
         "Pakse"
     ],
+    "name:eng_x_variant":[
+        "P\u0101ks\u0113"
+    ],
     "name:epo_x_preferred":[
         "Pakse"
     ],
@@ -67,8 +82,17 @@
     "name:fra_x_preferred":[
         "Paks\u00e9"
     ],
+    "name:fra_x_variant":[
+        "Pakx\u00e9"
+    ],
+    "name:gle_x_preferred":[
+        "Pakse"
+    ],
     "name:guj_x_preferred":[
         "\u0aaa\u0abe\u0a95\u0ab8\u0ac7"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e4\u05e7\u05e1\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u092a\u093e\u0915\u094d\u0938\u0947"
@@ -78,6 +102,9 @@
     ],
     "name:hun_x_preferred":[
         "Pakx\u00e9"
+    ],
+    "name:hye_x_preferred":[
+        "\u054a\u0561\u056f\u057d\u0565"
     ],
     "name:ido_x_preferred":[
         "Pakxe"
@@ -99,6 +126,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10de\u10d0\u10e5\u10e1\u10d4"
+    ],
+    "name:khm_x_preferred":[
+        "\u1794\u17c9\u17b6\u1780\u179f\u17c1"
     ],
     "name:kor_x_preferred":[
         "\ud30d\uc138"
@@ -158,6 +188,12 @@
     "name:spa_x_preferred":[
         "Pakse"
     ],
+    "name:spa_x_variant":[
+        "P\u0101ks\u0113"
+    ],
+    "name:sqi_x_preferred":[
+        "P\u0101ks\u0113"
+    ],
     "name:swe_x_preferred":[
         "Pakx\u00e9"
     ],
@@ -179,11 +215,17 @@
     "name:urd_x_preferred":[
         "\u067e\u0627\u06a9\u0633\u06d2"
     ],
+    "name:vec_x_preferred":[
+        "P\u0101ks\u0113"
+    ],
     "name:vie_x_preferred":[
         "Pakxe"
     ],
     "name:war_x_preferred":[
         "Pakse"
+    ],
+    "name:war_x_variant":[
+        "P\u0101ks\u0113"
     ],
     "name:zho_x_preferred":[
         "\u5df4\u8272"
@@ -313,7 +355,7 @@
         }
     ],
     "wof:id":890440015,
-    "wof:lastmodified":1566593357,
+    "wof:lastmodified":1690938503,
     "wof:name":"Pakx\u00e9",
     "wof:parent_id":1092028367,
     "wof:placetype":"locality",

--- a/data/890/443/897/890443897.geojson
+++ b/data/890/443/897/890443897.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0644\u0648\u0627\u0646\u063a \u0628\u0631\u0627\u0628\u0627\u0646\u063a"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0648\u0627\u0646\u062c \u0628\u0631\u0627\u0628\u0627\u0646\u062c"
+    ],
+    "name:ast_x_preferred":[
+        "Luang Prabang"
+    ],
     "name:bel_x_preferred":[
         "\u041b\u0443\u0430\u043d\u0433\u043f\u0445\u0430\u0431\u0430\u043d\u0433"
     ],
@@ -40,8 +46,14 @@
     "name:cat_x_preferred":[
         "Luang Prabang"
     ],
+    "name:cdo_x_preferred":[
+        "Luang Prabang"
+    ],
     "name:ceb_x_preferred":[
         "Louangphabang"
+    ],
+    "name:ceb_x_variant":[
+        "L\u016bang Phab\u0101ng"
     ],
     "name:ces_x_preferred":[
         "Luang Prabang"
@@ -85,6 +97,9 @@
     "name:fra_x_preferred":[
         "Luang Prabang"
     ],
+    "name:fra_x_variant":[
+        "Louang-Phabang"
+    ],
     "name:guj_x_preferred":[
         "\u0ab2\u0ac1\u0a86\u0a82\u0a97 \u0aaa\u0acd\u0ab0\u0aac\u0abe\u0a82\u0a97"
     ],
@@ -121,8 +136,17 @@
     "name:kat_x_preferred":[
         "\u10da\u10e3\u10d0\u10dc\u10d2\u10de\u10e0\u10d0\u10d1\u10d0\u10dc\u10d2\u10d8"
     ],
+    "name:khm_x_preferred":[
+        "\u17a0\u17d2\u179b\u17bd\u1784\u1796\u17d2\u179a\u17c7\u1794\u17b6\u17c6\u1784"
+    ],
     "name:kor_x_preferred":[
         "\ub8e8\uc559\ud504\ub77c\ubc29"
+    ],
+    "name:kor_x_variant":[
+        "\ub8e8\uc559\ud30c\ubc29"
+    ],
+    "name:krj_x_preferred":[
+        "L\u016bang Phab\u0101ng"
     ],
     "name:lao_x_preferred":[
         "\u0eab\u0ea5\u0ea7\u0e87\u0e9e\u0eb0\u0e9a\u0eb2\u0e87"
@@ -148,6 +172,9 @@
     "name:msa_x_preferred":[
         "Luang Prabang"
     ],
+    "name:mya_x_preferred":[
+        "\u101c\u103d\u1019\u103a\u1015\u101b\u102c\u1018\u103d\u1019\u103a\u1019\u103c\u102d\u102f\u1037"
+    ],
     "name:nan_x_preferred":[
         "Luang Prabang"
     ],
@@ -159,6 +186,9 @@
     ],
     "name:oci_x_preferred":[
         "Luang Prabang"
+    ],
+    "name:oss_x_preferred":[
+        "\u041b\u0443\u0430\u043d\u0433\u043f\u0445\u0430\u0431\u0430\u043d\u0433"
     ],
     "name:pan_x_preferred":[
         "\u0a32\u0a41\u0a06\u0a02\u0a17 \u0a2a\u0a30\u0a3e\u0a2c\u0a3e\u0a02\u0a17"
@@ -184,6 +214,9 @@
     "name:spa_x_preferred":[
         "Luang Prabang"
     ],
+    "name:spa_x_variant":[
+        "L\u016bang Phab\u0101ng"
+    ],
     "name:srp_x_preferred":[
         "\u041b\u0443\u0430\u043d\u0433 \u041f\u0440\u0430\u0431\u0430\u043d\u0433"
     ],
@@ -196,6 +229,9 @@
     "name:tel_x_preferred":[
         "\u0c32\u0c41\u0c06\u0c02\u0c17\u0c4d \u0c2a\u0c4d\u0c30\u0c2d\u0c3e\u0c02\u0c17\u0c4d"
     ],
+    "name:tgl_x_preferred":[
+        "L\u016bang Phab\u0101ng"
+    ],
     "name:tha_x_preferred":[
         "\u0e2b\u0e25\u0e27\u0e07\u0e1e\u0e23\u0e30\u0e1a\u0e32\u0e07"
     ],
@@ -204,6 +240,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u041b\u0443\u0430\u043d\u0433-\u041f\u0440\u0430\u0431\u0430\u043d\u0433"
+    ],
+    "name:ukr_x_variant":[
+        "\u041b\u0443\u0430\u043d\u0491\u043f\u0445\u0430\u0431\u0430\u043d\u0491"
     ],
     "name:urd_x_preferred":[
         "\u0644\u0648\u0627\u0646\u06af \u067e\u0631\u0627\u0628\u0627\u0646\u06af"
@@ -216,6 +255,12 @@
     ],
     "name:war_x_preferred":[
         "Luang Prabang"
+    ],
+    "name:war_x_variant":[
+        "L\u016bang Phab\u0101ng"
+    ],
+    "name:wuu_x_preferred":[
+        "\u7405\u52c3\u62c9\u90a6"
     ],
     "name:yue_x_preferred":[
         "\u9f8d\u5e15\u90a6"
@@ -350,7 +395,7 @@
         }
     ],
     "wof:id":890443897,
-    "wof:lastmodified":1566593358,
+    "wof:lastmodified":1690938505,
     "wof:name":"Louangphabang",
     "wof:parent_id":1092027403,
     "wof:placetype":"locality",

--- a/data/890/443/901/890443901.geojson
+++ b/data/890/443/901/890443901.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u062a\u0634\u0627\u0645\u0628\u0627\u0633\u0627\u0643"
     ],
+    "name:ast_x_preferred":[
+        "Champasak"
+    ],
     "name:ben_x_preferred":[
         "\u099a\u09cd\u09af\u09be\u09ae\u09aa\u09be\u09b8\u09be\u0995"
+    ],
+    "name:ceb_x_preferred":[
+        "Champasak"
     ],
     "name:ces_x_preferred":[
         "\u010campasak"
@@ -42,6 +48,12 @@
     ],
     "name:fra_x_preferred":[
         "Champassak"
+    ],
+    "name:fra_x_variant":[
+        "Bassac"
+    ],
+    "name:gle_x_preferred":[
+        "Camp\u0101sak"
     ],
     "name:heb_x_preferred":[
         "\u05e6'\u05de\u05e4\u05e1\u05d0\u05e7"
@@ -67,8 +79,14 @@
     "name:kat_x_preferred":[
         "\u10e2\u10d8\u10d0\u10db\u10de\u10d0\u10e2\u10e1\u10d0\u10d9\u10d8"
     ],
+    "name:khm_x_preferred":[
+        "\u1785\u17c6\u1794\u17c9\u17b6\u179f\u17b6\u1780\u17cb"
+    ],
     "name:kor_x_preferred":[
         "\ucc38\ube60\uc0ad"
+    ],
+    "name:krj_x_preferred":[
+        "Camp\u0101sak"
     ],
     "name:lao_x_preferred":[
         "\u0e88\u0eb3\u0e9b\u0eb2\u0eaa\u0eb1\u0e81"
@@ -91,11 +109,17 @@
     "name:spa_x_preferred":[
         "Champasak"
     ],
+    "name:spa_x_variant":[
+        "Camp\u0101sak"
+    ],
     "name:srp_x_preferred":[
         "\u0427\u0430\u043c\u043f\u0430\u0441\u0430\u043a"
     ],
     "name:swe_x_preferred":[
         "Champassak"
+    ],
+    "name:swe_x_variant":[
+        "Champasak"
     ],
     "name:tur_x_preferred":[
         "Champasak"
@@ -249,7 +273,7 @@
         }
     ],
     "wof:id":890443901,
-    "wof:lastmodified":1636495635,
+    "wof:lastmodified":1690938505,
     "wof:name":"Champasak",
     "wof:parent_id":1092027043,
     "wof:placetype":"locality",

--- a/data/890/455/947/890455947.geojson
+++ b/data/890/455/947/890455947.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0641\u0627\u0646\u062e\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0641\u0627\u0646\u062e\u062a"
+    ],
     "name:bel_x_preferred":[
         "\u0421\u0430\u0432\u0430\u043d\u0430\u043a\u0445\u0435\u0442"
     ],
@@ -73,16 +76,31 @@
     "name:fra_x_preferred":[
         "Savannakhet"
     ],
+    "name:fra_x_variant":[
+        "Kaison Ph\u00f4mvihan-Ville"
+    ],
     "name:fur_x_preferred":[
+        "Savannakhet"
+    ],
+    "name:gle_x_preferred":[
         "Savannakhet"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ab5\u0abe\u0aa8\u0acd\u0aa8\u0abe\u0a96\u0ac7\u0aa4"
     ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d5\u05d5\u05d0\u05e0\u05e7\u05d8"
+    ],
     "name:hin_x_preferred":[
         "\u0938\u0935\u093e\u0928\u0928\u093e\u0916\u0947\u0924"
     ],
+    "name:hin_x_variant":[
+        "\u0938\u0935\u0928\u094d\u0928\u093e\u0916\u0947\u0924"
+    ],
     "name:hrv_x_preferred":[
+        "Savannakhet"
+    ],
+    "name:ido_x_preferred":[
         "Savannakhet"
     ],
     "name:ind_x_preferred":[
@@ -105,6 +123,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10e1\u10d0\u10d5\u10d0\u10dc\u10d0\u10e5\u10d4\u10e2\u10d8"
+    ],
+    "name:khm_x_preferred":[
+        "\u179f\u17bb\u179c\u178e\u17d2\u178e\u1781\u17c1\u178f\u17d2\u178f"
     ],
     "name:kor_x_preferred":[
         "\uce74\uc774\uc190\ud3fc\ube44\ud55c"
@@ -196,6 +217,9 @@
     ],
     "name:wuu_x_preferred":[
         "\u51ef\u5c71\u4e30\u5a01\u6c49\u5e02"
+    ],
+    "name:yid_x_preferred":[
+        "\u05e7\u05f2\u05b7\u05e1\u05d0\u05b8\u05df\u05be\u05e4\u05bc\u05d0\u05b8\u05de\u05f0\u05d9\u05d4\u05d0\u05b8\u05df\u05be\u05e9\u05d8\u05d0\u05b8\u05d8"
     ],
     "name:yue_x_preferred":[
         "\u6c99\u7063\u90a3\u5409"
@@ -328,7 +352,7 @@
         }
     ],
     "wof:id":890455947,
-    "wof:lastmodified":1566593357,
+    "wof:lastmodified":1690938504,
     "wof:name":"Savannakh\u00e9t",
     "wof:parent_id":1092026527,
     "wof:placetype":"locality",

--- a/data/890/455/949/890455949.geojson
+++ b/data/890/455/949/890455949.geojson
@@ -19,11 +19,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "S\u0113k\u01edng"
+    ],
+    "name:ceb_x_preferred":[
+        "S\u0113k\u01edng"
+    ],
     "name:deu_x_preferred":[
         "Sekong"
     ],
+    "name:deu_x_variant":[
+        "S\u0113k\u01edng"
+    ],
     "name:eng_x_preferred":[
         "Sekong"
+    ],
+    "name:eng_x_variant":[
+        "S\u0113k\u01edng"
     ],
     "name:fas_x_preferred":[
         "\u0633\u06cc\u06a9\u0648\u0646\u06af"
@@ -31,17 +43,32 @@
     "name:fra_x_preferred":[
         "S\u00e9kong"
     ],
+    "name:fra_x_variant":[
+        "X\u00e9kong"
+    ],
     "name:jpn_x_preferred":[
         "\u30e9\u30de\u30fc\u30e0\u90e1"
+    ],
+    "name:khm_x_preferred":[
+        "\u179f\u17d2\u179a\u17c2\u1782\u1784\u17d2\u1782"
     ],
     "name:nld_x_preferred":[
         "Ban Phone"
     ],
+    "name:nld_x_variant":[
+        "S\u0113k\u01edng"
+    ],
     "name:pol_x_preferred":[
         "Ban Phone"
     ],
+    "name:pol_x_variant":[
+        "S\u0113k\u01edng"
+    ],
     "name:rus_x_preferred":[
         "\u041b\u0430\u043c\u0430\u043c"
+    ],
+    "name:spa_x_preferred":[
+        "S\u0113k\u01edng"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e01\u0e2d\u0e07"
@@ -86,7 +113,7 @@
         }
     ],
     "wof:id":890455949,
-    "wof:lastmodified":1566593357,
+    "wof:lastmodified":1690938504,
     "wof:name":"Lamam",
     "wof:parent_id":1092028877,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.