### PR TITLE
la concordances, placetype local, and more

### DIFF
--- a/data/109/202/614/5/1092026145.geojson
+++ b/data/109/202/614/5/1092026145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.233995,
-    "geom:area_square_m":2789654406.707381,
+    "geom:area_square_m":2789654838.179465,
     "geom:bbox":"106.983806,15.028438,107.69483,15.730089",
     "geom:latitude":15.388174,
     "geom:longitude":107.323194,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XE.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897567,
-    "wof:geomhash":"2e115e1ecd515116f42c751d114d1d46",
+    "wof:geomhash":"9fba2b92db2515c4670ed40883c8b951",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026145,
-    "wof:lastmodified":1627522315,
+    "wof:lastmodified":1695886778,
     "wof:name":"Dakchung",
     "wof:parent_id":85673473,
     "wof:placetype":"county",

--- a/data/109/202/619/3/1092026193.geojson
+++ b/data/109/202/619/3/1092026193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263775,
-    "geom:area_square_m":3019754878.82998,
+    "geom:area_square_m":3019754910.484845,
     "geom:bbox":"101.537844,21.882173,102.279429,22.502872",
     "geom:latitude":22.2041,
     "geom:longitude":101.869609,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.PH.NH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897569,
-    "wof:geomhash":"a94dd45e4aab7291957a5b10a40f6a9e",
+    "wof:geomhash":"66574723fc5f22987f47a10db74ceb2b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026193,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886785,
     "wof:name":"Gnot-Ou",
     "wof:parent_id":85673459,
     "wof:placetype":"county",

--- a/data/109/202/623/7/1092026237.geojson
+++ b/data/109/202/623/7/1092026237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085063,
-    "geom:area_square_m":1002090658.879427,
+    "geom:area_square_m":1002090658.879053,
     "geom:bbox":"100.965009,17.466021,101.273987324,17.9489354574",
     "geom:latitude":17.687921,
     "geom:longitude":101.111334,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XA.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897571,
-    "wof:geomhash":"ed516c4c7828572358daa7a2b16a4f34",
+    "wof:geomhash":"9cdce3ea4d3d93908ee04f8fa45195ea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092026237,
-    "wof:lastmodified":1566593296,
+    "wof:lastmodified":1695886702,
     "wof:name":"Boten",
     "wof:parent_id":85673417,
     "wof:placetype":"county",

--- a/data/109/202/628/5/1092026285.geojson
+++ b/data/109/202/628/5/1092026285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01948,
-    "geom:area_square_m":229193348.228387,
+    "geom:area_square_m":229193520.973633,
     "geom:bbox":"102.588521,17.803142,102.907648,18.016258",
     "geom:latitude":17.915524,
     "geom:longitude":102.728933,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.VT.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897572,
-    "wof:geomhash":"14ab67d874f91be10ab21b9997b0b166",
+    "wof:geomhash":"b96b3371a29e0f8253568d4f36b68d11",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026285,
-    "wof:lastmodified":1627522316,
+    "wof:lastmodified":1695886779,
     "wof:name":"Hatxayfong",
     "wof:parent_id":85673433,
     "wof:placetype":"county",

--- a/data/109/202/631/5/1092026315.geojson
+++ b/data/109/202/631/5/1092026315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.277625,
-    "geom:area_square_m":3302074984.260542,
+    "geom:area_square_m":3302074590.028031,
     "geom:bbox":"106.65323,15.569931,107.466643,16.183214",
     "geom:latitude":15.867263,
     "geom:longitude":107.034324,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XE.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897574,
-    "wof:geomhash":"c568d0ba2e063bd958b0613afd068a8b",
+    "wof:geomhash":"bfc918d6f34a4af7dacd59655a063e98",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1092026315,
-    "wof:lastmodified":1627522316,
+    "wof:lastmodified":1695886779,
     "wof:name":"Karum",
     "wof:parent_id":85673473,
     "wof:placetype":"county",

--- a/data/109/202/639/1/1092026391.geojson
+++ b/data/109/202/639/1/1092026391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059771,
-    "geom:area_square_m":695932363.777475,
+    "geom:area_square_m":695932457.55271,
     "geom:bbox":"100.403787,19.498852,100.701193,19.830758",
     "geom:latitude":19.675357,
     "geom:longitude":100.561719,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XA.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897576,
-    "wof:geomhash":"5af258a5157bab26d97cd6af281d3cbc",
+    "wof:geomhash":"6b6f4f31a112fa6a5d45e502c96546d1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026391,
-    "wof:lastmodified":1627522317,
+    "wof:lastmodified":1695886780,
     "wof:name":"Khop",
     "wof:parent_id":85673417,
     "wof:placetype":"county",

--- a/data/109/202/643/5/1092026435.geojson
+++ b/data/109/202/643/5/1092026435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.222537,
-    "geom:area_square_m":2569001516.710433,
+    "geom:area_square_m":2569001516.710216,
     "geom:bbox":"100.509212,20.6617167217,101.160780972,21.315766",
     "geom:latitude":20.996661,
     "geom:longitude":100.833841,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LM.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897577,
-    "wof:geomhash":"234b84504ec92bf339241beb1217881d",
+    "wof:geomhash":"d72a75b9ec3da29984bf43bd172d5d1b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092026435,
-    "wof:lastmodified":1566593286,
+    "wof:lastmodified":1695886702,
     "wof:name":"Long",
     "wof:parent_id":85673413,
     "wof:placetype":"county",

--- a/data/109/202/648/1/1092026481.geojson
+++ b/data/109/202/648/1/1092026481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.251944,
-    "geom:area_square_m":2900870345.579368,
+    "geom:area_square_m":2900870345.578979,
     "geom:bbox":"102.464475758,21.0070297115,102.993228,21.845964",
     "geom:latitude":21.383102,
     "geom:longitude":102.721442,
@@ -107,9 +107,10 @@
     "wof:concordances":{
         "hasc:id":"LA.PH.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897579,
-    "wof:geomhash":"6e61af76690e7b12a0145187ad3c6206",
+    "wof:geomhash":"cae8d433ac7067724dbb4b1dcc10083b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092026481,
-    "wof:lastmodified":1566593297,
+    "wof:lastmodified":1695886702,
     "wof:name":"Mai",
     "wof:parent_id":85673459,
     "wof:placetype":"county",

--- a/data/109/202/652/7/1092026527.geojson
+++ b/data/109/202/652/7/1092026527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055204,
-    "geom:area_square_m":654218818.124512,
+    "geom:area_square_m":654218818.124552,
     "geom:bbox":"104.733283,16.4248161019,105.007858154,16.7480176462",
     "geom:latitude":16.583256,
     "geom:longitude":104.855997,
@@ -149,9 +149,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897581,
-    "wof:geomhash":"44747c9822f65ab5402146eafd9e86c0",
+    "wof:geomhash":"e1c437a31e49ad8763e13544046e1f15",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1092026527,
-    "wof:lastmodified":1566593298,
+    "wof:lastmodified":1695886702,
     "wof:name":"Kaysone Phomvihane",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/657/7/1092026577.geojson
+++ b/data/109/202/657/7/1092026577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190509,
-    "geom:area_square_m":2282777852.012643,
+    "geom:area_square_m":2282777725.098383,
     "geom:bbox":"105.205587,14.086921,105.874939,14.514676",
     "geom:latitude":14.291716,
     "geom:longitude":105.566639,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.CH.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897582,
-    "wof:geomhash":"fc32b602466d0c02edf94382f8581fa3",
+    "wof:geomhash":"c96b3f471de66dca705a8a98bdb83cf3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026577,
-    "wof:lastmodified":1627522318,
+    "wof:lastmodified":1695886780,
     "wof:name":"Mounlapamok",
     "wof:parent_id":85673423,
     "wof:placetype":"county",

--- a/data/109/202/661/7/1092026617.geojson
+++ b/data/109/202/661/7/1092026617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.248111,
-    "geom:area_square_m":2847468636.089633,
+    "geom:area_square_m":2847469071.045241,
     "geom:bbox":"101.937942,21.45157,102.450113,22.217216",
     "geom:latitude":21.852821,
     "geom:longitude":102.182637,
@@ -119,9 +119,10 @@
     "wof:concordances":{
         "hasc:id":"LA.PH.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897584,
-    "wof:geomhash":"971df67d8b26d78116cbfa41061f3108",
+    "wof:geomhash":"895024cdde28a03b4121f01f4827501a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092026617,
-    "wof:lastmodified":1636495633,
+    "wof:lastmodified":1695886659,
     "wof:name":"Phongsali",
     "wof:parent_id":85673459,
     "wof:placetype":"county",

--- a/data/109/202/666/1/1092026661.geojson
+++ b/data/109/202/666/1/1092026661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.279308,
-    "geom:area_square_m":3335745568.777898,
+    "geom:area_square_m":3335745049.796749,
     "geom:bbox":"106.776995,14.690737,107.599227,15.291166",
     "geom:latitude":15.016646,
     "geom:longitude":107.215998,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.AT.SX"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897585,
-    "wof:geomhash":"3d240327de6243a4dc159a598baa3cb6",
+    "wof:geomhash":"321683c468b37462ff3cd585642d063d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026661,
-    "wof:lastmodified":1627522322,
+    "wof:lastmodified":1695886784,
     "wof:name":"Sanxai",
     "wof:parent_id":85673469,
     "wof:placetype":"county",

--- a/data/109/202/670/7/1092026707.geojson
+++ b/data/109/202/670/7/1092026707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116284,
-    "geom:area_square_m":1381104334.254001,
+    "geom:area_square_m":1381104179.423715,
     "geom:bbox":"105.021296,15.968883,105.572423,16.335469",
     "geom:latitude":16.153301,
     "geom:longitude":105.311877,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897587,
-    "wof:geomhash":"5c43eddd0d7da52b4061b5e470d4dcc8",
+    "wof:geomhash":"92e11b1d878a8397a5abda8903c44d6d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026707,
-    "wof:lastmodified":1627522322,
+    "wof:lastmodified":1695886784,
     "wof:name":"Songkhon",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/674/1/1092026741.geojson
+++ b/data/109/202/674/1/1092026741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088769,
-    "geom:area_square_m":1027232537.926426,
+    "geom:area_square_m":1027232422.7807,
     "geom:bbox":"104.13291,20.469147,104.640016,20.822343",
     "geom:latitude":20.634044,
     "geom:longitude":104.393915,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.HO.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897588,
-    "wof:geomhash":"b2dca063b0534df6f04cc9a56fcde2a1",
+    "wof:geomhash":"6d80191f9f1cfedf1f0fd236a22d47b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026741,
-    "wof:lastmodified":1627522322,
+    "wof:lastmodified":1695886784,
     "wof:name":"Sopbao",
     "wof:parent_id":85673447,
     "wof:placetype":"county",

--- a/data/109/202/678/5/1092026785.geojson
+++ b/data/109/202/678/5/1092026785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075874,
-    "geom:area_square_m":878929849.01251,
+    "geom:area_square_m":878929682.222541,
     "geom:bbox":"100.083872,20.24412,100.54804,20.667886",
     "geom:latitude":20.474577,
     "geom:longitude":100.249114,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BK.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897590,
-    "wof:geomhash":"46d2c603e754d68f6222338f76a03631",
+    "wof:geomhash":"f7e5cb88f3747806a39f6a7269305df3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026785,
-    "wof:lastmodified":1627522323,
+    "wof:lastmodified":1695886784,
     "wof:name":"Tonpheung",
     "wof:parent_id":85673409,
     "wof:placetype":"county",

--- a/data/109/202/682/9/1092026829.geojson
+++ b/data/109/202/682/9/1092026829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.340773,
-    "geom:area_square_m":3961180659.303534,
+    "geom:area_square_m":3961180722.453322,
     "geom:bbox":"104.13235,19.609125,104.993292,20.23121",
     "geom:latitude":19.93672,
     "geom:longitude":104.534208,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.HO.XT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897591,
-    "wof:geomhash":"e9316d5721a1c2aa6152a6c95a839d05",
+    "wof:geomhash":"20fb361dd3c45a916a0305788301b54e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026829,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886786,
     "wof:name":"Xam-Tai",
     "wof:parent_id":85673447,
     "wof:placetype":"county",

--- a/data/109/202/686/9/1092026869.geojson
+++ b/data/109/202/686/9/1092026869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.278076,
-    "geom:area_square_m":3282880138.577371,
+    "geom:area_square_m":3282880317.145918,
     "geom:bbox":"105.523347,17.009697,106.431929,17.676665",
     "geom:latitude":17.301073,
     "geom:longitude":105.941158,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.KH.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897593,
-    "wof:geomhash":"957cfd60de10d5db5d3eaf0b0459ef73",
+    "wof:geomhash":"cb2fd299d4e62e3acb9f63355920e191",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026869,
-    "wof:lastmodified":1627522315,
+    "wof:lastmodified":1695886778,
     "wof:name":"Boualapha",
     "wof:parent_id":85673467,
     "wof:placetype":"county",

--- a/data/109/202/691/9/1092026919.geojson
+++ b/data/109/202/691/9/1092026919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.191936,
-    "geom:area_square_m":2272427797.500528,
+    "geom:area_square_m":2272427719.789223,
     "geom:bbox":"106.014335,16.541143,106.652518,17.02027",
     "geom:latitude":16.7662,
     "geom:longitude":106.334723,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897594,
-    "wof:geomhash":"83d0a6f75691de2885fb01dc27893e8d",
+    "wof:geomhash":"d2fbb6f64e2e40e0f91614fce56ba31b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026919,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886786,
     "wof:name":"Xepon",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/696/5/1092026965.geojson
+++ b/data/109/202/696/5/1092026965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070298,
-    "geom:area_square_m":812482236.725238,
+    "geom:area_square_m":812482452.010991,
     "geom:bbox":"104.004613,20.667243,104.385198,20.978451",
     "geom:latitude":20.82023,
     "geom:longitude":104.18623,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.HO.XI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897596,
-    "wof:geomhash":"c6bf094a0305955e2a5a8148c2efe865",
+    "wof:geomhash":"cebdb4ae37cbfca37ce49b968b2eb455",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092026965,
-    "wof:lastmodified":1627522318,
+    "wof:lastmodified":1695886780,
     "wof:name":"Xiangkho",
     "wof:parent_id":85673447,
     "wof:placetype":"county",

--- a/data/109/202/700/9/1092027009.geojson
+++ b/data/109/202/700/9/1092027009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074266,
-    "geom:area_square_m":885988627.269778,
+    "geom:area_square_m":885988394.61276,
     "geom:bbox":"105.818115,15.033934,106.132088,15.470085",
     "geom:latitude":15.246386,
     "geom:longitude":105.967188,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.CH.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897597,
-    "wof:geomhash":"9d419b574ab833939877ed844e913e77",
+    "wof:geomhash":"eacbc88f2970ae2471b39c4e261218a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027009,
-    "wof:lastmodified":1627522314,
+    "wof:lastmodified":1695886777,
     "wof:name":"Bachiangchareunsouk",
     "wof:parent_id":85673423,
     "wof:placetype":"county",

--- a/data/109/202/704/3/1092027043.geojson
+++ b/data/109/202/704/3/1092027043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075085,
-    "geom:area_square_m":897407276.467526,
+    "geom:area_square_m":897407319.193084,
     "geom:bbox":"105.517547,14.654473,105.932782,15.034708",
     "geom:latitude":14.85493,
     "geom:longitude":105.754037,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"LA.CH.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897599,
-    "wof:geomhash":"900d2c44988b7e9884185836b9c209c3",
+    "wof:geomhash":"fef87a7806190f243c271a1f5ef9f42b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1092027043,
-    "wof:lastmodified":1636495633,
+    "wof:lastmodified":1695886659,
     "wof:name":"Champasak",
     "wof:parent_id":85673423,
     "wof:placetype":"county",

--- a/data/109/202/705/9/1092027059.geojson
+++ b/data/109/202/705/9/1092027059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076633,
-    "geom:area_square_m":906450739.652569,
+    "geom:area_square_m":906450847.708039,
     "geom:bbox":"104.735697,16.720719,105.185644,17.109862",
     "geom:latitude":16.943718,
     "geom:longitude":104.923381,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.XB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897601,
-    "wof:geomhash":"46b14372b0799c221488a2d33b57e8a3",
+    "wof:geomhash":"58d1b142be6651abf19a65ea90c9637a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027059,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886786,
     "wof:name":"Xaibouri",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/706/1/1092027061.geojson
+++ b/data/109/202/706/1/1092027061.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897602,
     "wof:geomhash":"da7b6d3bcc9ad8978d3190d103f49429",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092027061,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886779,
     "wof:name":"Hinheup",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/706/3/1092027063.geojson
+++ b/data/109/202/706/3/1092027063.geojson
@@ -64,6 +64,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897604,
     "wof:geomhash":"c636d8bdb1f5061035ccee828c388294",
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092027063,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886779,
     "wof:name":"Kasi",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/709/3/1092027093.geojson
+++ b/data/109/202/709/3/1092027093.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.FE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897605,
     "wof:geomhash":"01491da83292d3eab5f07d93006aa339",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092027093,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886778,
     "wof:name":"Fuang",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/713/1/1092027131.geojson
+++ b/data/109/202/713/1/1092027131.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897607,
     "wof:geomhash":"b94dfa5f1fd9507133d4672c2415bcf9",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092027131,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886780,
     "wof:name":"Keo-Oudom",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/715/3/1092027153.geojson
+++ b/data/109/202/715/3/1092027153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.200835,
-    "geom:area_square_m":2352822060.712757,
+    "geom:area_square_m":2352821983.238543,
     "geom:bbox":"102.645635,18.490412,103.515575,18.940536",
     "geom:latitude":18.660053,
     "geom:longitude":103.110298,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XS.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897608,
-    "wof:geomhash":"50d60daa0ef2fdf206ac4a62e080f63d",
+    "wof:geomhash":"4928eb6ed5d11d14199743623127466c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027153,
-    "wof:lastmodified":1627522316,
+    "wof:lastmodified":1695886779,
     "wof:name":"Hom",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/719/7/1092027197.geojson
+++ b/data/109/202/719/7/1092027197.geojson
@@ -130,6 +130,7 @@
     "wof:concordances":{
         "hasc:id":"LA.XI.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897610,
     "wof:geomhash":"6ebb5badeec16a55e6333d1b3e48848a",
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1092027197,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886703,
     "wof:name":"Kham",
     "wof:parent_id":85673441,
     "wof:placetype":"county",

--- a/data/109/202/722/9/1092027229.geojson
+++ b/data/109/202/722/9/1092027229.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.XI.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897611,
     "wof:geomhash":"d307813250d0d30b0b78fb2ba9e55bc9",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092027229,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886780,
     "wof:name":"Khoun",
     "wof:parent_id":85673441,
     "wof:placetype":"county",

--- a/data/109/202/726/5/1092027265.geojson
+++ b/data/109/202/726/5/1092027265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106301,
-    "geom:area_square_m":1224315203.852087,
+    "geom:area_square_m":1224315101.83103,
     "geom:bbox":"101.726497,21.141318,102.202591,21.552065",
     "geom:latitude":21.338883,
     "geom:longitude":101.979161,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.PH.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897613,
-    "wof:geomhash":"b436289ca8d2e7395d6ebbae3a79030d",
+    "wof:geomhash":"f2fbcf6a4e9d5cd409e8af02f3a93c2e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027265,
-    "wof:lastmodified":1627522318,
+    "wof:lastmodified":1695886781,
     "wof:name":"Boun-Tai",
     "wof:parent_id":85673459,
     "wof:placetype":"county",

--- a/data/109/202/729/9/1092027299.geojson
+++ b/data/109/202/729/9/1092027299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094809,
-    "geom:area_square_m":1095055363.983983,
+    "geom:area_square_m":1095055670.866975,
     "geom:bbox":"101.914019,20.724028,102.363799,21.144093",
     "geom:latitude":20.918922,
     "geom:longitude":102.132691,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"LA.OU.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897614,
-    "wof:geomhash":"b419c9f8f55cb9444abaaf71c76eb685",
+    "wof:geomhash":"337db7590260ec8be06914a6a74e5b10",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1092027299,
-    "wof:lastmodified":1627522317,
+    "wof:lastmodified":1695886780,
     "wof:name":"La",
     "wof:parent_id":85673453,
     "wof:placetype":"county",

--- a/data/109/202/734/1/1092027341.geojson
+++ b/data/109/202/734/1/1092027341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185861,
-    "geom:area_square_m":2145264619.379956,
+    "geom:area_square_m":2145264790.371342,
     "geom:bbox":"101.158739,20.767114,101.773536,21.256354",
     "geom:latitude":21.020038,
     "geom:longitude":101.44606,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LM.NT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897616,
-    "wof:geomhash":"cc1281055a58158111e9445947a9cefb",
+    "wof:geomhash":"7d942df19575a0923e46fba83c8fa187",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027341,
-    "wof:lastmodified":1627522317,
+    "wof:lastmodified":1695886780,
     "wof:name":"Luangnamtha",
     "wof:parent_id":85673413,
     "wof:placetype":"county",

--- a/data/109/202/738/1/1092027381.geojson
+++ b/data/109/202/738/1/1092027381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108596,
-    "geom:area_square_m":1262687622.184303,
+    "geom:area_square_m":1262687138.262302,
     "geom:bbox":"101.724884,19.638491,102.242909,20.090854",
     "geom:latitude":19.892508,
     "geom:longitude":101.959673,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897617,
-    "wof:geomhash":"6072d719d9342daa7ea207a9621012d1",
+    "wof:geomhash":"8fc6ee1c6f4a7431a80c27d351538cd9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027381,
-    "wof:lastmodified":1627522315,
+    "wof:lastmodified":1695886778,
     "wof:name":"Chomphet",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/202/740/3/1092027403.geojson
+++ b/data/109/202/740/3/1092027403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072152,
-    "geom:area_square_m":839281217.884234,
+    "geom:area_square_m":839281732.782381,
     "geom:bbox":"101.807013,19.631599,102.460191,20.008221",
     "geom:latitude":19.827681,
     "geom:longitude":102.15601,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897619,
-    "wof:geomhash":"10b389cdb0759716d4143f77b67e9c71",
+    "wof:geomhash":"f71de29b06446451566f4d5dded488c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027403,
-    "wof:lastmodified":1627522317,
+    "wof:lastmodified":1695886780,
     "wof:name":"Luangprabang",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/202/744/9/1092027449.geojson
+++ b/data/109/202/744/9/1092027449.geojson
@@ -82,6 +82,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897620,
     "wof:geomhash":"8ee3edb0b0021e47eddd058b189dcf4c",
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092027449,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886781,
     "wof:name":"Met",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/748/5/1092027485.geojson
+++ b/data/109/202/748/5/1092027485.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.XA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897622,
     "wof:geomhash":"afbf1a0771d320c70a44d8c275c2b2d9",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092027485,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886781,
     "wof:name":"Meun",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/750/7/1092027507.geojson
+++ b/data/109/202/750/7/1092027507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214136,
-    "geom:area_square_m":2508199690.26378,
+    "geom:area_square_m":2508199703.688928,
     "geom:bbox":"103.466933,18.461596,104.104253,18.954501",
     "geom:latitude":18.689866,
     "geom:longitude":103.765689,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BL.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897623,
-    "wof:geomhash":"2b0c244d466cf8d5d42ae31cad82aaf9",
+    "wof:geomhash":"7f4041a45e71a485a4384c4603acebf6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027507,
-    "wof:lastmodified":1627522315,
+    "wof:lastmodified":1695886778,
     "wof:name":"Borikhan",
     "wof:parent_id":85673463,
     "wof:placetype":"county",

--- a/data/109/202/754/9/1092027549.geojson
+++ b/data/109/202/754/9/1092027549.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.XI.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897625,
     "wof:geomhash":"8d380572a5cc7c2d924f3ed8083cb749",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092027549,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886781,
     "wof:name":"Mokmai",
     "wof:parent_id":85673441,
     "wof:placetype":"county",

--- a/data/109/202/757/9/1092027579.geojson
+++ b/data/109/202/757/9/1092027579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.143706,
-    "geom:area_square_m":1664246405.977446,
+    "geom:area_square_m":1664246768.233759,
     "geom:bbox":"101.018157,20.304753,101.573099,20.788644",
     "geom:latitude":20.516006,
     "geom:longitude":101.335029,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LM.NL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897626,
-    "wof:geomhash":"8c406329289090ca51330ddf936ed550",
+    "wof:geomhash":"3cb1a0cbf425c991df65cfa1aebcfd37",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027579,
-    "wof:lastmodified":1627522318,
+    "wof:lastmodified":1695886781,
     "wof:name":"Nale",
     "wof:parent_id":85673413,
     "wof:placetype":"county",

--- a/data/109/202/761/9/1092027619.geojson
+++ b/data/109/202/761/9/1092027619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.145839,
-    "geom:area_square_m":1690638861.522909,
+    "geom:area_square_m":1690638861.523032,
     "geom:bbox":"101.453296915,20.1280666897,102.000472893,20.5635513338",
     "geom:latitude":20.362589,
     "geom:longitude":101.71637,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"LA.OU.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897628,
-    "wof:geomhash":"66d6754a5f52919eca0779c5ef20ea0f",
+    "wof:geomhash":"6d2ab5031b052dfe2910e4c64a3b3b3f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092027619,
-    "wof:lastmodified":1566593294,
+    "wof:lastmodified":1695886702,
     "wof:name":"Beng",
     "wof:parent_id":85673453,
     "wof:placetype":"county",

--- a/data/109/202/765/7/1092027657.geojson
+++ b/data/109/202/765/7/1092027657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.182714,
-    "geom:area_square_m":2121885328.906738,
+    "geom:area_square_m":2121885513.812993,
     "geom:bbox":"101.15707,19.827777,101.761347,20.363404",
     "geom:latitude":20.085288,
     "geom:longitude":101.43189,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.OU.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897629,
-    "wof:geomhash":"584dc6c3f5613971f06b74c4040435e6",
+    "wof:geomhash":"f814651eb160d2562c38e8491459705a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027657,
-    "wof:lastmodified":1627522316,
+    "wof:lastmodified":1695886779,
     "wof:name":"Houn",
     "wof:parent_id":85673453,
     "wof:placetype":"county",

--- a/data/109/202/768/3/1092027683.geojson
+++ b/data/109/202/768/3/1092027683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169485,
-    "geom:area_square_m":1961817850.62368,
+    "geom:area_square_m":1961817602.982648,
     "geom:bbox":"102.139237,20.24035,102.654837,20.948111",
     "geom:latitude":20.591025,
     "geom:longitude":102.390844,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.NM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897631,
-    "wof:geomhash":"318ebb782c9a342eca736190a32ac6f0",
+    "wof:geomhash":"bf339514d7ef4f64225d71b36f53af95",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027683,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886781,
     "wof:name":"Nambak",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/202/772/1/1092027721.geojson
+++ b/data/109/202/772/1/1092027721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120206,
-    "geom:area_square_m":1401973287.92061,
+    "geom:area_square_m":1401973691.747234,
     "geom:bbox":"101.797081,19.04826,102.147609,19.656697",
     "geom:latitude":19.399376,
     "geom:longitude":101.938064,
@@ -140,9 +140,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.NN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897632,
-    "wof:geomhash":"c2f09e9d6a24918190e78a7cc2459b3f",
+    "wof:geomhash":"f767385ca1bd7deb2dcac29baa255ace",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1092027721,
-    "wof:lastmodified":1636495634,
+    "wof:lastmodified":1695886659,
     "wof:name":"Nan",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/202/774/7/1092027747.geojson
+++ b/data/109/202/774/7/1092027747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002089,
-    "geom:area_square_m":24568679.217288,
+    "geom:area_square_m":24568692.80407,
     "geom:bbox":"102.58645,17.953374,102.626439,18.040053",
     "geom:latitude":18.000474,
     "geom:longitude":102.609187,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.VT.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897634,
-    "wof:geomhash":"dfaafb5ae13c8cebe636a03014cb780f",
+    "wof:geomhash":"98ad4c84a8ca41c9ab2f3f09ed8c54c5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027747,
-    "wof:lastmodified":1627522315,
+    "wof:lastmodified":1695886778,
     "wof:name":"Chanthabouri",
     "wof:parent_id":85673433,
     "wof:placetype":"county",

--- a/data/109/202/779/5/1092027795.geojson
+++ b/data/109/202/779/5/1092027795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077217,
-    "geom:area_square_m":907200241.770779,
+    "geom:area_square_m":907199748.553502,
     "geom:bbox":"102.258326,18.026125,102.620262,18.336492",
     "geom:latitude":18.168597,
     "geom:longitude":102.431699,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.VT.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897636,
-    "wof:geomhash":"47ac017769d94fa717113c0a508d3f8e",
+    "wof:geomhash":"7eda816d1e4dc61bcf9d35add87d82fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027795,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886781,
     "wof:name":"Naxaythong",
     "wof:parent_id":85673433,
     "wof:placetype":"county",

--- a/data/109/202/783/7/1092027837.geojson
+++ b/data/109/202/783/7/1092027837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13778,
-    "geom:area_square_m":1603874650.92853,
+    "geom:area_square_m":1603874859.921305,
     "geom:bbox":"101.241199,19.484689,101.773223,19.936088",
     "geom:latitude":19.708245,
     "geom:longitude":101.493538,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XA.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897637,
-    "wof:geomhash":"eea661f092bd45eac7c87bcb09dfb5c3",
+    "wof:geomhash":"56dc4eefa2816cdfaafcb77f29412cca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092027837,
-    "wof:lastmodified":1627522316,
+    "wof:lastmodified":1695886779,
     "wof:name":"Hongsa",
     "wof:parent_id":85673417,
     "wof:placetype":"county",

--- a/data/109/202/786/7/1092027867.geojson
+++ b/data/109/202/786/7/1092027867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.171319,
-    "geom:area_square_m":1988244494.848839,
+    "geom:area_square_m":1988244954.330964,
     "geom:bbox":"101.588374,19.862269,102.203469,20.525867",
     "geom:latitude":20.187742,
     "geom:longitude":101.945142,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.OU.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897639,
-    "wof:geomhash":"c4e15e2d8f28200d828b10e2f18215ee",
+    "wof:geomhash":"fc65e34a10a681fff071f46967cab759",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027867,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886781,
     "wof:name":"Nga",
     "wof:parent_id":85673453,
     "wof:placetype":"county",

--- a/data/109/202/791/3/1092027913.geojson
+++ b/data/109/202/791/3/1092027913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153357,
-    "geom:area_square_m":1769616081.600058,
+    "geom:area_square_m":1769616081.599958,
     "geom:bbox":"102.015503584,20.8303120354,102.746053869,21.2731120598",
     "geom:latitude":21.060835,
     "geom:longitude":102.368396,
@@ -113,9 +113,10 @@
     "wof:concordances":{
         "hasc:id":"LA.PH.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897640,
-    "wof:geomhash":"48f0e249d01463628354de6033ab7c59",
+    "wof:geomhash":"fff3b2c5e1004c79ae67b4da0c3e89fd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1092027913,
-    "wof:lastmodified":1566593284,
+    "wof:lastmodified":1695886702,
     "wof:name":"Khoa",
     "wof:parent_id":85673459,
     "wof:placetype":"county",

--- a/data/109/202/796/1/1092027961.geojson
+++ b/data/109/202/796/1/1092027961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.245863,
-    "geom:area_square_m":2843440916.586454,
+    "geom:area_square_m":2843441001.737818,
     "geom:bbox":"102.409311,20.299045,103.070423,21.134255",
     "geom:latitude":20.722487,
     "geom:longitude":102.748287,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897641,
-    "wof:geomhash":"c982b90c3c87a780d681d3c30cea5fe7",
+    "wof:geomhash":"2aecbe3f5931b7a5545b6f264b487049",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092027961,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886781,
     "wof:name":"Ngoy",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/202/800/1/1092028001.geojson
+++ b/data/109/202/800/1/1092028001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.123148,
-    "geom:area_square_m":1456627874.408949,
+    "geom:area_square_m":1456628132.048573,
     "geom:bbox":"105.119326,16.778272,105.678501,17.103018",
     "geom:latitude":16.945874,
     "geom:longitude":105.394453,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.AP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897648,
-    "wof:geomhash":"475f5226f04d3b2431edfac31f3b9c8e",
+    "wof:geomhash":"56184b0eff6f436f99a952955f264fe1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028001,
-    "wof:lastmodified":1627522314,
+    "wof:lastmodified":1695886777,
     "wof:name":"Atsaphon",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/804/7/1092028047.geojson
+++ b/data/109/202/804/7/1092028047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089688,
-    "geom:area_square_m":1061860690.597603,
+    "geom:area_square_m":1061860344.855135,
     "geom:bbox":"104.869364,16.548463,105.191469,16.961255",
     "geom:latitude":16.766449,
     "geom:longitude":105.041044,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897650,
-    "wof:geomhash":"d0208b60038d03f8b4b2d1790c58be18",
+    "wof:geomhash":"289d6f1077be39a77b60456c181ef25f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028047,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886781,
     "wof:name":"Outhoumphon",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/808/5/1092028085.geojson
+++ b/data/109/202/808/5/1092028085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090168,
-    "geom:area_square_m":1069067384.747686,
+    "geom:area_square_m":1069067449.33556,
     "geom:bbox":"104.995707,16.309673,105.463006,16.665519",
     "geom:latitude":16.492748,
     "geom:longitude":105.209741,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897651,
-    "wof:geomhash":"e515fc8929dc13d5d583b119fa1c309b",
+    "wof:geomhash":"ee28e61e97a0f77382b39ed8dc681f95",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028085,
-    "wof:lastmodified":1627522315,
+    "wof:lastmodified":1695886778,
     "wof:name":"Champhon",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/812/5/1092028125.geojson
+++ b/data/109/202/812/5/1092028125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029365,
-    "geom:area_square_m":347115847.096516,
+    "geom:area_square_m":347115860.442812,
     "geom:bbox":"104.729331,16.903298,104.945133,17.199852",
     "geom:latitude":17.063712,
     "geom:longitude":104.821207,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.KH.NO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897652,
-    "wof:geomhash":"40eb9db71de550d0989ded0e72cce545",
+    "wof:geomhash":"243347c6a93214219f66d410af3ac70f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028125,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886782,
     "wof:name":"Nongbok",
     "wof:parent_id":85673467,
     "wof:placetype":"county",

--- a/data/109/202/815/7/1092028157.geojson
+++ b/data/109/202/815/7/1092028157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05615,
-    "geom:area_square_m":659823114.176771,
+    "geom:area_square_m":659823127.219752,
     "geom:bbox":"102.849504,17.971238,103.153606,18.303179",
     "geom:latitude":18.131894,
     "geom:longitude":102.973404,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.VT.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897654,
-    "wof:geomhash":"c4a57d6fbd9f02a7ea49b5e3b1ee4573",
+    "wof:geomhash":"26362d54078585e5540c2220e03f7713",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028157,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886782,
     "wof:name":"Pak-Ngum",
     "wof:parent_id":85673433,
     "wof:placetype":"county",

--- a/data/109/202/820/5/1092028205.geojson
+++ b/data/109/202/820/5/1092028205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077644,
-    "geom:area_square_m":901208231.469102,
+    "geom:area_square_m":901208391.601514,
     "geom:bbox":"102.143309,19.954163,102.519901,20.321928",
     "geom:latitude":20.169268,
     "geom:longitude":102.322362,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897655,
-    "wof:geomhash":"249f83234275886f34831290ea217a31",
+    "wof:geomhash":"1d31cd7320f5d55be0e1461ab027c07e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028205,
-    "wof:lastmodified":1627522320,
+    "wof:lastmodified":1695886782,
     "wof:name":"Pak-Ou",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/202/824/5/1092028245.geojson
+++ b/data/109/202/824/5/1092028245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098768,
-    "geom:area_square_m":1148001817.123334,
+    "geom:area_square_m":1148002417.708666,
     "geom:bbox":"100.731161,19.81696,101.430654,20.137787",
     "geom:latitude":19.948674,
     "geom:longitude":101.067701,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"LA.OU.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897657,
-    "wof:geomhash":"740dcd96dcc6050653207b57f50d6cee",
+    "wof:geomhash":"61f3e07f29759e09340517773f944e26",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1092028245,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886782,
     "wof:name":"Pakbeng",
     "wof:parent_id":85673453,
     "wof:placetype":"county",

--- a/data/109/202/827/3/1092028273.geojson
+++ b/data/109/202/827/3/1092028273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.173655,
-    "geom:area_square_m":2037533907.265658,
+    "geom:area_square_m":2037533795.181204,
     "geom:bbox":"101.160936,17.990171,101.846689,18.864714",
     "geom:latitude":18.396248,
     "geom:longitude":101.48161,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XA.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897658,
-    "wof:geomhash":"5a064a2abf4ec22779467924b22a9682",
+    "wof:geomhash":"365972f3bdffade145667844a7e3c0a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028273,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886782,
     "wof:name":"Paklai",
     "wof:parent_id":85673417,
     "wof:placetype":"county",

--- a/data/109/202/831/5/1092028315.geojson
+++ b/data/109/202/831/5/1092028315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063051,
-    "geom:area_square_m":739648774.843342,
+    "geom:area_square_m":739648774.843478,
     "geom:bbox":"103.470818304,18.283761,103.929218229,18.5431996512",
     "geom:latitude":18.431088,
     "geom:longitude":103.728246,
@@ -116,9 +116,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BL.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897659,
-    "wof:geomhash":"71e828839dd3f388a5f91e56f675c6dc",
+    "wof:geomhash":"a60197f0c939c6bd29a86ffc5a9aa25b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1092028315,
-    "wof:lastmodified":1566593298,
+    "wof:lastmodified":1695886703,
     "wof:name":"Pakxan",
     "wof:parent_id":85673463,
     "wof:placetype":"county",

--- a/data/109/202/836/7/1092028367.geojson
+++ b/data/109/202/836/7/1092028367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010359,
-    "geom:area_square_m":123649068.06854,
+    "geom:area_square_m":123649132.461765,
     "geom:bbox":"105.728834,15.049357,105.88341,15.181551",
     "geom:latitude":15.135397,
     "geom:longitude":105.819892,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.CH.PE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897661,
-    "wof:geomhash":"562fce009df2198673d7e75fa8e81bf5",
+    "wof:geomhash":"9ebc5e2e4baa35a21761046f7cc7b45d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028367,
-    "wof:lastmodified":1627522320,
+    "wof:lastmodified":1695886782,
     "wof:name":"Pakxe",
     "wof:parent_id":85673423,
     "wof:placetype":"county",

--- a/data/109/202/840/7/1092028407.geojson
+++ b/data/109/202/840/7/1092028407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14132,
-    "geom:area_square_m":1640192337.625258,
+    "geom:area_square_m":1640192086.510795,
     "geom:bbox":"102.313399,19.976238,102.993961,20.433218",
     "geom:latitude":20.179081,
     "geom:longitude":102.664803,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.PX"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897663,
-    "wof:geomhash":"2aaea212401591a36da04ab768bcd291",
+    "wof:geomhash":"f1edc29e73c9d857955931db92ac8699",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028407,
-    "wof:lastmodified":1627522320,
+    "wof:lastmodified":1695886782,
     "wof:name":"Pakxeng",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/202/844/1/1092028441.geojson
+++ b/data/109/202/844/1/1092028441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077964,
-    "geom:area_square_m":929078391.543752,
+    "geom:area_square_m":929078660.186933,
     "geom:bbox":"105.941052,15.283702,106.367648,15.639226",
     "geom:latitude":15.478788,
     "geom:longitude":106.143699,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SL.LN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897664,
-    "wof:geomhash":"24ddb98af22b2c0eef41b04f4b4ae702",
+    "wof:geomhash":"35650abe836a9bc1157e67acde2946a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028441,
-    "wof:lastmodified":1627522317,
+    "wof:lastmodified":1695886780,
     "wof:name":"Laongam",
     "wof:parent_id":85673427,
     "wof:placetype":"county",

--- a/data/109/202/847/9/1092028479.geojson
+++ b/data/109/202/847/9/1092028479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.290676,
-    "geom:area_square_m":3470087728.022227,
+    "geom:area_square_m":3470087665.394678,
     "geom:bbox":"106.016805,14.764124,106.827767,15.412053",
     "geom:latitude":15.104219,
     "geom:longitude":106.436506,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.CH.PG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897666,
-    "wof:geomhash":"c2b845458a03a734909152a98bf3117b",
+    "wof:geomhash":"ea922423d4a89ca7c458f26971ec26fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028479,
-    "wof:lastmodified":1627522320,
+    "wof:lastmodified":1695886782,
     "wof:name":"Pakxong",
     "wof:parent_id":85673423,
     "wof:placetype":"county",

--- a/data/109/202/852/3/1092028523.geojson
+++ b/data/109/202/852/3/1092028523.geojson
@@ -64,6 +64,7 @@
     "wof:concordances":{
         "hasc:id":"LA.XI.PE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897667,
     "wof:geomhash":"a22d906f6de93154a8615c73243e2e00",
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092028523,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886782,
     "wof:name":"Pek",
     "wof:parent_id":85673441,
     "wof:placetype":"county",

--- a/data/109/202/854/9/1092028549.geojson
+++ b/data/109/202/854/9/1092028549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161198,
-    "geom:area_square_m":1870672939.521341,
+    "geom:area_square_m":1870672357.187843,
     "geom:bbox":"100.647602,19.989624,101.254457,20.4027",
     "geom:latitude":20.198049,
     "geom:longitude":100.93172,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BK.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897669,
-    "wof:geomhash":"4caf91c1588037693915200bbd4d525f",
+    "wof:geomhash":"4fade9b2dac87067604e840fee62507d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028549,
-    "wof:lastmodified":1627522320,
+    "wof:lastmodified":1695886782,
     "wof:name":"Pha-Oudom",
     "wof:parent_id":85673409,
     "wof:placetype":"county",

--- a/data/109/202/859/1/1092028591.geojson
+++ b/data/109/202/859/1/1092028591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084792,
-    "geom:area_square_m":1004252650.401409,
+    "geom:area_square_m":1004252717.669585,
     "geom:bbox":"105.407271,16.510359,105.7564,16.959945",
     "geom:latitude":16.698827,
     "geom:longitude":105.606264,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.TX"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897670,
-    "wof:geomhash":"58879b481fbe567d56f2c06fa70917f5",
+    "wof:geomhash":"483122e8106bd8b9ca07377450c58682",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028591,
-    "wof:lastmodified":1627522320,
+    "wof:lastmodified":1695886782,
     "wof:name":"Phalanxai",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/863/1/1092028631.geojson
+++ b/data/109/202/863/1/1092028631.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897672,
     "wof:geomhash":"b6a80bfa32701f004b798ce5e9965b34",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092028631,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886782,
     "wof:name":"Phonhong",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/866/3/1092028663.geojson
+++ b/data/109/202/866/3/1092028663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07666,
-    "geom:area_square_m":915146665.598451,
+    "geom:area_square_m":915146336.217964,
     "geom:bbox":"105.46679,14.949459,105.862197,15.33188",
     "geom:latitude":15.109422,
     "geom:longitude":105.650622,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.CH.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897673,
-    "wof:geomhash":"211556c498df88f894e9aeebf3d19fa9",
+    "wof:geomhash":"40cb3d5309aa309e3332ac3facdbf30f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028663,
-    "wof:lastmodified":1627522321,
+    "wof:lastmodified":1695886783,
     "wof:name":"Phonthong",
     "wof:parent_id":85673423,
     "wof:placetype":"county",

--- a/data/109/202/870/3/1092028703.geojson
+++ b/data/109/202/870/3/1092028703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.206141,
-    "geom:area_square_m":2396936212.317421,
+    "geom:area_square_m":2396935608.393686,
     "geom:bbox":"102.330502,19.677399,103.137897,20.093812",
     "geom:latitude":19.888603,
     "geom:longitude":102.728534,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897675,
-    "wof:geomhash":"757c5eec3942feaa4fd87b888f160b21",
+    "wof:geomhash":"0b82b32b27291fb123ee57893f1f7fb0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028703,
-    "wof:lastmodified":1627522321,
+    "wof:lastmodified":1695886783,
     "wof:name":"Phonxai",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/202/874/5/1092028745.geojson
+++ b/data/109/202/874/5/1092028745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053131,
-    "geom:area_square_m":630482597.256028,
+    "geom:area_square_m":630482766.426342,
     "geom:bbox":"106.732574,16.167595,107.071105,16.55023",
     "geom:latitude":16.32638,
     "geom:longitude":106.893418,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SL.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897676,
-    "wof:geomhash":"294a93f4abd643be75dbeb0f6c401ee8",
+    "wof:geomhash":"85bebe7028718508b3a15ad9af8fc9d7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028745,
-    "wof:lastmodified":1627522321,
+    "wof:lastmodified":1695886783,
     "wof:name":"Samouay",
     "wof:parent_id":85673427,
     "wof:placetype":"county",

--- a/data/109/202/877/3/1092028773.geojson
+++ b/data/109/202/877/3/1092028773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040869,
-    "geom:area_square_m":488295313.616737,
+    "geom:area_square_m":488295946.185682,
     "geom:bbox":"106.680605,14.708152,106.876503,15.238708",
     "geom:latitude":14.928939,
     "geom:longitude":106.790718,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.AT.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897678,
-    "wof:geomhash":"240f5f3b924035433633353e2de83946",
+    "wof:geomhash":"45d369d6e3409175a77ac7e801363bd6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028773,
-    "wof:lastmodified":1627522321,
+    "wof:lastmodified":1695886783,
     "wof:name":"Samakkhixai",
     "wof:parent_id":85673469,
     "wof:placetype":"county",

--- a/data/109/202/880/7/1092028807.geojson
+++ b/data/109/202/880/7/1092028807.geojson
@@ -64,6 +64,7 @@
     "wof:concordances":{
         "hasc:id":"LA.AT.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897680,
     "wof:geomhash":"20e0b4271632ecb51aeffd933a1831bb",
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092028807,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886783,
     "wof:name":"Sanamxai",
     "wof:parent_id":85673469,
     "wof:placetype":"county",

--- a/data/109/202/884/1/1092028841.geojson
+++ b/data/109/202/884/1/1092028841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060389,
-    "geom:area_square_m":709076642.759234,
+    "geom:area_square_m":709076532.863676,
     "geom:bbox":"102.01308,18.045421,102.345645,18.436352",
     "geom:latitude":18.269835,
     "geom:longitude":102.16917,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.VT.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897681,
-    "wof:geomhash":"b7809f94a1d889e1c0094da059f3fdd3",
+    "wof:geomhash":"fec1b35ffc8afc40b41cb052a3c338ea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028841,
-    "wof:lastmodified":1627522322,
+    "wof:lastmodified":1695886784,
     "wof:name":"Sangthong",
     "wof:parent_id":85673433,
     "wof:placetype":"county",

--- a/data/109/202/887/7/1092028877.geojson
+++ b/data/109/202/887/7/1092028877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149183,
-    "geom:area_square_m":1778359403.532654,
+    "geom:area_square_m":1778359011.557425,
     "geom:bbox":"106.549232,15.13218,107.043268,15.64116",
     "geom:latitude":15.410144,
     "geom:longitude":106.805678,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XE.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897683,
-    "wof:geomhash":"272889ebcf466e02bfd616f571200c1d",
+    "wof:geomhash":"cc7dad45d414007d29f4d77c2c76f09b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028877,
-    "wof:lastmodified":1627522317,
+    "wof:lastmodified":1695886780,
     "wof:name":"Laman",
     "wof:parent_id":85673473,
     "wof:placetype":"county",

--- a/data/109/202/891/1/1092028911.geojson
+++ b/data/109/202/891/1/1092028911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.196265,
-    "geom:area_square_m":2336072582.332452,
+    "geom:area_square_m":2336072292.171053,
     "geom:bbox":"106.000731,15.482111,106.711213,15.975813",
     "geom:latitude":15.720911,
     "geom:longitude":106.368565,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SL.SV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897684,
-    "wof:geomhash":"adb43a23c8177c350831f229009a085a",
+    "wof:geomhash":"3108378bfe1f5d460d045d5057fba242",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092028911,
-    "wof:lastmodified":1636495634,
+    "wof:lastmodified":1695886659,
     "wof:name":"Saravan",
     "wof:parent_id":85673427,
     "wof:placetype":"county",

--- a/data/109/202/895/3/1092028953.geojson
+++ b/data/109/202/895/3/1092028953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012548,
-    "geom:area_square_m":147556849.227235,
+    "geom:area_square_m":147557174.258422,
     "geom:bbox":"102.367242,17.960092,102.608302,18.039376",
     "geom:latitude":18.002616,
     "geom:longitude":102.498187,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.VT.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897686,
-    "wof:geomhash":"777dfbc7ef671fb6db87608ee9630ef6",
+    "wof:geomhash":"2f656854865094429771daf63d417391",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028953,
-    "wof:lastmodified":1627522322,
+    "wof:lastmodified":1695886784,
     "wof:name":"Sikhottabong",
     "wof:parent_id":85673433,
     "wof:placetype":"county",

--- a/data/109/202/899/3/1092028993.geojson
+++ b/data/109/202/899/3/1092028993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002076,
-    "geom:area_square_m":24428474.183747,
+    "geom:area_square_m":24428546.015482,
     "geom:bbox":"102.605147,17.906648,102.659938,17.968258",
     "geom:latitude":17.934105,
     "geom:longitude":102.631513,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.VT.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897687,
-    "wof:geomhash":"bf245e25f1fe74e84a6676817fc22ad1",
+    "wof:geomhash":"cf49fb76dafe225fd722a8b13249c803",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092028993,
-    "wof:lastmodified":1627522322,
+    "wof:lastmodified":1695886784,
     "wof:name":"Sisattanak",
     "wof:parent_id":85673433,
     "wof:placetype":"county",

--- a/data/109/202/901/5/1092029015.geojson
+++ b/data/109/202/901/5/1092029015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102928,
-    "geom:area_square_m":1231516494.65839,
+    "geom:area_square_m":1231516435.310479,
     "geom:bbox":"105.473752,14.449811,105.867532,14.812219",
     "geom:latitude":14.620579,
     "geom:longitude":105.67295,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.CH.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897689,
-    "wof:geomhash":"2d1c91772c18680d7f0528d815dda77d",
+    "wof:geomhash":"a747df9b964032d23605ad5cc71cd86e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029015,
-    "wof:lastmodified":1627522322,
+    "wof:lastmodified":1695886784,
     "wof:name":"Soukhouma",
     "wof:parent_id":85673423,
     "wof:placetype":"county",

--- a/data/109/202/905/7/1092029057.geojson
+++ b/data/109/202/905/7/1092029057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.285518,
-    "geom:area_square_m":3386134295.967686,
+    "geom:area_square_m":3386134295.96678,
     "geom:bbox":"105.674966348,16.0515815341,106.40885629,16.8194359109",
     "geom:latitude":16.439911,
     "geom:longitude":106.02978,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897690,
-    "wof:geomhash":"3a945406380bceb8e681b421087946e4",
+    "wof:geomhash":"778f65e28577986cbb5b93f67d1d944d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1092029057,
-    "wof:lastmodified":1566593293,
+    "wof:lastmodified":1695886702,
     "wof:name":"Phin",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/909/9/1092029099.geojson
+++ b/data/109/202/909/9/1092029099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.215518,
-    "geom:area_square_m":2560719230.263587,
+    "geom:area_square_m":2560719905.767279,
     "geom:bbox":"106.32538,15.782955,107.156925,16.347828",
     "geom:latitude":16.074506,
     "geom:longitude":106.692101,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SL.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897692,
-    "wof:geomhash":"6566ed890eeee18a234e441f7785982c",
+    "wof:geomhash":"a5f4a623c5d36f7f895e4d50ea30c72f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029099,
-    "wof:lastmodified":1627522322,
+    "wof:lastmodified":1695886784,
     "wof:name":"Ta-Oy",
     "wof:parent_id":85673427,
     "wof:placetype":"county",

--- a/data/109/202/913/5/1092029135.geojson
+++ b/data/109/202/913/5/1092029135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107811,
-    "geom:area_square_m":1282538648.379086,
+    "geom:area_square_m":1282538567.668317,
     "geom:bbox":"105.342227,15.643511,105.85897,16.000862",
     "geom:latitude":15.830902,
     "geom:longitude":105.600823,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SL.LK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897693,
-    "wof:geomhash":"39c97cdad76e2ff9d37647a1060dfa3c",
+    "wof:geomhash":"5de98d58216be51df0787a8257d45a53",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029135,
-    "wof:lastmodified":1627522317,
+    "wof:lastmodified":1695886780,
     "wof:name":"Lakhonpheng",
     "wof:parent_id":85673427,
     "wof:placetype":"county",

--- a/data/109/202/917/1/1092029171.geojson
+++ b/data/109/202/917/1/1092029171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.178933,
-    "geom:area_square_m":2125863896.39816,
+    "geom:area_square_m":2125864443.108352,
     "geom:bbox":"105.510956,15.876764,106.142643,16.319563",
     "geom:latitude":16.090682,
     "geom:longitude":105.805281,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.TT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897695,
-    "wof:geomhash":"1c925baff08f37c6efbf7409956b945f",
+    "wof:geomhash":"74730aec6eee021db2cb9dda1128e1c8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029171,
-    "wof:lastmodified":1627522323,
+    "wof:lastmodified":1695886784,
     "wof:name":"Thapangthong",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/920/5/1092029205.geojson
+++ b/data/109/202/920/5/1092029205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102195,
-    "geom:area_square_m":1194828045.220399,
+    "geom:area_square_m":1194828166.576072,
     "geom:bbox":"103.274155,18.820768,103.898134,19.15594",
     "geom:latitude":18.99878,
     "geom:longitude":103.608734,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XS.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897696,
-    "wof:geomhash":"a09de80d86fdda99bdf159560650abeb",
+    "wof:geomhash":"89632195f4362c3468cc0a23047ea262",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029205,
-    "wof:lastmodified":1627522323,
+    "wof:lastmodified":1695886784,
     "wof:name":"Thathom",
     "wof:parent_id":85673441,
     "wof:placetype":"county",

--- a/data/109/202/924/5/1092029245.geojson
+++ b/data/109/202/924/5/1092029245.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897698,
     "wof:geomhash":"85bd8636341fe7845663c3f9d2979cee",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092029245,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886784,
     "wof:name":"Thoulakhom",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/927/9/1092029279.geojson
+++ b/data/109/202/927/9/1092029279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0566,
-    "geom:area_square_m":672677809.374254,
+    "geom:area_square_m":672677828.591258,
     "geom:bbox":"106.102416,15.868794,106.372059,16.179442",
     "geom:latitude":16.025192,
     "geom:longitude":106.242718,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SL.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897700,
-    "wof:geomhash":"7b783b0f551eed4678c3cd65782fa4d2",
+    "wof:geomhash":"fce8c43a9ef9fed0ed16f914c055c115",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029279,
-    "wof:lastmodified":1627522323,
+    "wof:lastmodified":1695886784,
     "wof:name":"Toumlan",
     "wof:parent_id":85673427,
     "wof:placetype":"county",

--- a/data/109/202/932/3/1092029323.geojson
+++ b/data/109/202/932/3/1092029323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147255,
-    "geom:area_square_m":1716295221.213625,
+    "geom:area_square_m":1716295775.651599,
     "geom:bbox":"102.337096,19.211681,102.869895,19.774816",
     "geom:latitude":19.508863,
     "geom:longitude":102.590872,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.PK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897701,
-    "wof:geomhash":"b8ddf33d79bb2b3cb1a3848363fe09c0",
+    "wof:geomhash":"789bfea9e6d83b70e0083c8521387b08",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029323,
-    "wof:lastmodified":1627522321,
+    "wof:lastmodified":1695886783,
     "wof:name":"Phoukhoun",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/202/936/7/1092029367.geojson
+++ b/data/109/202/936/7/1092029367.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897702,
     "wof:geomhash":"9e654034a619c4361ec07bd5f8f9eb57",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092029367,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886784,
     "wof:name":"Vangvieng",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/939/9/1092029399.geojson
+++ b/data/109/202/939/9/1092029399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06698,
-    "geom:area_square_m":797912462.804706,
+    "geom:area_square_m":797912435.479224,
     "geom:bbox":"105.592637,15.431168,105.953315,15.688761",
     "geom:latitude":15.547247,
     "geom:longitude":105.769312,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SL.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897704,
-    "wof:geomhash":"6542f13acad6aa277cf65e617526b769",
+    "wof:geomhash":"8fb3b2a4f0ba708b07f13d9cab583214",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029399,
-    "wof:lastmodified":1627522317,
+    "wof:lastmodified":1695886780,
     "wof:name":"Khongxedon",
     "wof:parent_id":85673427,
     "wof:placetype":"county",

--- a/data/109/202/944/1/1092029441.geojson
+++ b/data/109/202/944/1/1092029441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081486,
-    "geom:area_square_m":969738257.843622,
+    "geom:area_square_m":969738257.843847,
     "geom:bbox":"105.787529733,15.5492617842,106.120930211,15.9662300737",
     "geom:latitude":15.754948,
     "geom:longitude":105.96359,
@@ -134,9 +134,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SL.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897705,
-    "wof:geomhash":"d7672ad2ab577940a75bc84afddf8761",
+    "wof:geomhash":"096f0f919c091ba617f9fd14e94562d8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1092029441,
-    "wof:lastmodified":1566593302,
+    "wof:lastmodified":1695886703,
     "wof:name":"Vapi",
     "wof:parent_id":85673427,
     "wof:placetype":"county",

--- a/data/109/202/948/9/1092029489.geojson
+++ b/data/109/202/948/9/1092029489.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.VI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897707,
     "wof:geomhash":"efd20d93cf5c26aa3a13e595668071a8",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092029489,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886785,
     "wof:name":"Viangkham",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/202/951/3/1092029513.geojson
+++ b/data/109/202/951/3/1092029513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159303,
-    "geom:area_square_m":1843092823.245744,
+    "geom:area_square_m":1843092923.022988,
     "geom:bbox":"100.810235,20.354935,101.327462,20.974885",
     "geom:latitude":20.663475,
     "geom:longitude":101.067844,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LM.VI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897708,
-    "wof:geomhash":"2909a5270dea54b016710b13df753305",
+    "wof:geomhash":"b0a621a57e718672f9352b25fed8f949",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029513,
-    "wof:lastmodified":1627522323,
+    "wof:lastmodified":1695886784,
     "wof:name":"Viangphoukha",
     "wof:parent_id":85673413,
     "wof:placetype":"county",

--- a/data/109/202/955/9/1092029559.geojson
+++ b/data/109/202/955/9/1092029559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.255339,
-    "geom:area_square_m":3004663441.417367,
+    "geom:area_square_m":3004663557.304511,
     "geom:bbox":"104.264122,17.5534,104.87331,18.229287",
     "geom:latitude":17.888538,
     "geom:longitude":104.583715,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.KH.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897710,
-    "wof:geomhash":"b5d917faf2bbe359a1d3662671b1f036",
+    "wof:geomhash":"f3a1fb39de29b3308e31f83cfdcc2d86",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029559,
-    "wof:lastmodified":1627522316,
+    "wof:lastmodified":1695886779,
     "wof:name":"Hinboun",
     "wof:parent_id":85673467,
     "wof:placetype":"county",

--- a/data/109/202/960/5/1092029605.geojson
+++ b/data/109/202/960/5/1092029605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.361768,
-    "geom:area_square_m":4237802978.304883,
+    "geom:area_square_m":4237803050.887316,
     "geom:bbox":"104.052583,18.22,104.762777,19.120128",
     "geom:latitude":18.674683,
     "geom:longitude":104.412987,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BL.VI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897711,
-    "wof:geomhash":"e1325718f834b2ad39b004618ae56a8c",
+    "wof:geomhash":"69b5b14a381736b936f0107a42d3d6ce",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029605,
-    "wof:lastmodified":1627522324,
+    "wof:lastmodified":1695886785,
     "wof:name":"Viangthong",
     "wof:parent_id":85673463,
     "wof:placetype":"county",

--- a/data/109/202/964/9/1092029649.geojson
+++ b/data/109/202/964/9/1092029649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.315653,
-    "geom:area_square_m":3659985561.768541,
+    "geom:area_square_m":3659985605.236728,
     "geom:bbox":"103.111778,19.868021,103.677934,20.827352",
     "geom:latitude":20.328142,
     "geom:longitude":103.372229,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.HO.VT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897713,
-    "wof:geomhash":"ca8612b28bbfad2b8a32cbedaa7c018b",
+    "wof:geomhash":"82796a8b70f5c1d1df2bcf970fc9e9eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029649,
-    "wof:lastmodified":1627522324,
+    "wof:lastmodified":1695886785,
     "wof:name":"Viangthong",
     "wof:parent_id":85673447,
     "wof:placetype":"county",

--- a/data/109/202/969/1/1092029691.geojson
+++ b/data/109/202/969/1/1092029691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149889,
-    "geom:area_square_m":1772988478.336271,
+    "geom:area_square_m":1772988439.765875,
     "geom:bbox":"105.637392,16.716985,106.333113,17.121918",
     "geom:latitude":16.940322,
     "geom:longitude":105.931556,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.VI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897715,
-    "wof:geomhash":"afa4aa34cf025b5e379d10ba8aa8f676",
+    "wof:geomhash":"daec5894ff1c5049438ed1f4a80d32ed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029691,
-    "wof:lastmodified":1627522324,
+    "wof:lastmodified":1695886785,
     "wof:name":"Vilabouri",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/202/973/9/1092029739.geojson
+++ b/data/109/202/973/9/1092029739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185065,
-    "geom:area_square_m":2141031434.207533,
+    "geom:area_square_m":2141031207.344411,
     "geom:bbox":"101.549769,20.479937,102.346068,20.993395",
     "geom:latitude":20.672247,
     "geom:longitude":101.953154,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.OU.XA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897716,
-    "wof:geomhash":"a1cd3c9a929e5f0f27c8e407b7b31bce",
+    "wof:geomhash":"ec57c8263b9f59cfcab7119e7d7970f1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029739,
-    "wof:lastmodified":1627522316,
+    "wof:lastmodified":1695886779,
     "wof:name":"Xai",
     "wof:parent_id":85673453,
     "wof:placetype":"county",

--- a/data/109/202/978/3/1092029783.geojson
+++ b/data/109/202/978/3/1092029783.geojson
@@ -64,6 +64,7 @@
     "wof:concordances":{
         "hasc:id":"LA.AT.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897718,
     "wof:geomhash":"1391b4c4d49f53a0c1f7d5adc6cb7b49",
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092029783,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886784,
     "wof:name":"Sanamxai",
     "wof:parent_id":85673469,
     "wof:placetype":"county",

--- a/data/109/202/981/9/1092029819.geojson
+++ b/data/109/202/981/9/1092029819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.259665,
-    "geom:area_square_m":3107527323.549831,
+    "geom:area_square_m":3107527176.194718,
     "geom:bbox":"106.557061,14.292068,107.541447,14.805081",
     "geom:latitude":14.571767,
     "geom:longitude":107.005349,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.AT.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897719,
-    "wof:geomhash":"91387a0ec6c680ac0fbb75326fb08852",
+    "wof:geomhash":"a2e056f8aa7e6e1f28b2412aefa717f1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029819,
-    "wof:lastmodified":1627522321,
+    "wof:lastmodified":1695886783,
     "wof:name":"Phouvong",
     "wof:parent_id":85673469,
     "wof:placetype":"county",

--- a/data/109/202/986/5/1092029865.geojson
+++ b/data/109/202/986/5/1092029865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059573,
-    "geom:area_square_m":712004783.388723,
+    "geom:area_square_m":712004988.023209,
     "geom:bbox":"106.789166,14.698039,107.263456,15.211263",
     "geom:latitude":14.857293,
     "geom:longitude":106.983959,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.AT.XA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897721,
-    "wof:geomhash":"3b1880d80b541b6eea5407e91f294c60",
+    "wof:geomhash":"81f7ceb191f02996aea41ac208cec4cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029865,
-    "wof:lastmodified":1627522324,
+    "wof:lastmodified":1695886785,
     "wof:name":"Xaisettha",
     "wof:parent_id":85673469,
     "wof:placetype":"county",

--- a/data/109/202/992/5/1092029925.geojson
+++ b/data/109/202/992/5/1092029925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011273,
-    "geom:area_square_m":132587644.991592,
+    "geom:area_square_m":132587384.844922,
     "geom:bbox":"102.620074,17.917319,102.780959,18.030417",
     "geom:latitude":17.97749,
     "geom:longitude":102.692645,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.VT.XS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897722,
-    "wof:geomhash":"01e8edff72fb4732babf951f03d8b914",
+    "wof:geomhash":"b0ae0dae7a87cf1b54a8c4b2c5ddfe8b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029925,
-    "wof:lastmodified":1627522324,
+    "wof:lastmodified":1695886785,
     "wof:name":"Xaisettha",
     "wof:parent_id":85673433,
     "wof:placetype":"county",

--- a/data/109/202/995/5/1092029955.geojson
+++ b/data/109/202/995/5/1092029955.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.XI.PK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897724,
     "wof:geomhash":"96d0f262a574d052d7eef58df000437e",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092029955,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886783,
     "wof:name":"Phoukout",
     "wof:parent_id":85673441,
     "wof:placetype":"county",

--- a/data/109/202/999/7/1092029997.geojson
+++ b/data/109/202/999/7/1092029997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.35442,
-    "geom:area_square_m":4144273872.847675,
+    "geom:area_square_m":4144274544.116287,
     "geom:bbox":"102.529214,18.666735,103.444707,19.311546",
     "geom:latitude":18.976657,
     "geom:longitude":102.929457,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XS.XA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897725,
-    "wof:geomhash":"f72038aca5c4df893767bd44824f8b7c",
+    "wof:geomhash":"3fe5c17f141fea0f65130297b7f31da8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092029997,
-    "wof:lastmodified":1627522324,
+    "wof:lastmodified":1695886785,
     "wof:name":"Xaisomboun",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/203/004/3/1092030043.geojson
+++ b/data/109/203/004/3/1092030043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070837,
-    "geom:area_square_m":832349260.378328,
+    "geom:area_square_m":832349243.360028,
     "geom:bbox":"102.564387,17.988112,102.893563,18.310961",
     "geom:latitude":18.145381,
     "geom:longitude":102.744742,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.VT.XT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897727,
-    "wof:geomhash":"ee801d087a8119aa79fadeb1063082ed",
+    "wof:geomhash":"54de31ecb7ba0650c5f522d2647f1a35",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030043,
-    "wof:lastmodified":1627522324,
+    "wof:lastmodified":1695886785,
     "wof:name":"Xaithani",
     "wof:parent_id":85673433,
     "wof:placetype":"county",

--- a/data/109/203/008/7/1092030087.geojson
+++ b/data/109/203/008/7/1092030087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265601,
-    "geom:area_square_m":3078496195.217364,
+    "geom:area_square_m":3078495746.069237,
     "geom:bbox":"103.498222,20.065785,104.388642,20.681222",
     "geom:latitude":20.386231,
     "geom:longitude":103.93591,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.HO.XN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897728,
-    "wof:geomhash":"f83a23f3a55e86018f4c5dcffff89ea3",
+    "wof:geomhash":"0dc4ecde6c87f0f0558a3abca7585fa9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030087,
-    "wof:lastmodified":1627522321,
+    "wof:lastmodified":1695886783,
     "wof:name":"Xam-Nua",
     "wof:parent_id":85673447,
     "wof:placetype":"county",

--- a/data/109/203/012/5/1092030125.geojson
+++ b/data/109/203/012/5/1092030125.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.VI.XA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897730,
     "wof:geomhash":"a575a7bdc782347862ff0195bb9e3d70",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092030125,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886786,
     "wof:name":"Xanakham",
     "wof:parent_id":85673437,
     "wof:placetype":"county",

--- a/data/109/203/021/5/1092030215.geojson
+++ b/data/109/203/021/5/1092030215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062536,
-    "geom:area_square_m":727888985.516005,
+    "geom:area_square_m":727888651.29004,
     "geom:bbox":"100.963013,19.572127,101.285704,19.88826",
     "geom:latitude":19.726583,
     "geom:longitude":101.134397,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XA.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897732,
-    "wof:geomhash":"fff5c3a9e9e4b6e8e2b4c2a3245b4b66",
+    "wof:geomhash":"f99da435c49424c2428369f5dfb81b9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030215,
-    "wof:lastmodified":1627522318,
+    "wof:lastmodified":1695886781,
     "wof:name":"Ngeun",
     "wof:parent_id":85673417,
     "wof:placetype":"county",

--- a/data/109/203/024/9/1092030249.geojson
+++ b/data/109/203/024/9/1092030249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.270424,
-    "geom:area_square_m":3155337830.975642,
+    "geom:area_square_m":3155337700.106596,
     "geom:bbox":"101.186834,18.850843,101.893994,19.659433",
     "geom:latitude":19.32996,
     "geom:longitude":101.590582,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XA.XA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897734,
-    "wof:geomhash":"19c51ce1418a529d20e6e4e15b0718ab",
+    "wof:geomhash":"9184c7b8a83007721e2648a1642207a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030249,
-    "wof:lastmodified":1627522322,
+    "wof:lastmodified":1695886784,
     "wof:name":"Xayabury",
     "wof:parent_id":85673417,
     "wof:placetype":"county",

--- a/data/109/203/029/3/1092030293.geojson
+++ b/data/109/203/029/3/1092030293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083122,
-    "geom:area_square_m":980738939.312353,
+    "geom:area_square_m":980738962.884483,
     "geom:bbox":"104.654439,17.172563,105.013312,17.598609",
     "geom:latitude":17.409067,
     "geom:longitude":104.868244,
@@ -137,9 +137,10 @@
     "wof:concordances":{
         "hasc:id":"LA.KH.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897735,
-    "wof:geomhash":"bd4634b6f41cca04e66458b32b00e132",
+    "wof:geomhash":"7efe59ab5c425b545312b163dcb472b7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1092030293,
-    "wof:lastmodified":1636495633,
+    "wof:lastmodified":1695886659,
     "wof:name":"Thakhek",
     "wof:parent_id":85673467,
     "wof:placetype":"county",

--- a/data/109/203/033/9/1092030339.geojson
+++ b/data/109/203/033/9/1092030339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079868,
-    "geom:area_square_m":943541314.983206,
+    "geom:area_square_m":943541395.371084,
     "geom:bbox":"104.881979,17.047542,105.360722,17.379673",
     "geom:latitude":17.176496,
     "geom:longitude":105.116522,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.KH.XE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897737,
-    "wof:geomhash":"08c9abcb18ff337d9f77915d066f6568",
+    "wof:geomhash":"06151a44cc99c46369765650b8c48c5a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030339,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886786,
     "wof:name":"Xebangfai",
     "wof:parent_id":85673467,
     "wof:placetype":"county",

--- a/data/109/203/037/3/1092030373.geojson
+++ b/data/109/203/037/3/1092030373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077921,
-    "geom:area_square_m":920518495.176558,
+    "geom:area_square_m":920518108.104357,
     "geom:bbox":"105.339244,17.03732,105.781017,17.307731",
     "geom:latitude":17.180074,
     "geom:longitude":105.545656,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.KH.XA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897738,
-    "wof:geomhash":"918ca2d3797c9a97fb8e072b64b404de",
+    "wof:geomhash":"49e3a06052e556059bd70bf7d7d1232c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030373,
-    "wof:lastmodified":1627522324,
+    "wof:lastmodified":1695886785,
     "wof:name":"Xaibouathong",
     "wof:parent_id":85673467,
     "wof:placetype":"county",

--- a/data/109/203/041/3/1092030413.geojson
+++ b/data/109/203/041/3/1092030413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138801,
-    "geom:area_square_m":1616667736.576107,
+    "geom:area_square_m":1616667673.002789,
     "geom:bbox":"102.022089,19.369907,102.572875,19.852877",
     "geom:latitude":19.618216,
     "geom:longitude":102.247612,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.XI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897740,
-    "wof:geomhash":"f74ca4c385601778ef061ab9850159de",
+    "wof:geomhash":"dff76374f3cbd2a2e64bc37dd61dbde3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030413,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886786,
     "wof:name":"Xiang-Ngeun",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/203/045/9/1092030459.geojson
+++ b/data/109/203/045/9/1092030459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076347,
-    "geom:area_square_m":887325314.420676,
+    "geom:area_square_m":887325384.822472,
     "geom:bbox":"100.439036,19.770885,100.773109,20.222394",
     "geom:latitude":19.962395,
     "geom:longitude":100.619222,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BK.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897741,
-    "wof:geomhash":"47584b7e7cc3e4a5cb559e158f93baef",
+    "wof:geomhash":"b1a112c436477abd4994f8433b859bca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030459,
-    "wof:lastmodified":1627522320,
+    "wof:lastmodified":1695886782,
     "wof:name":"Paktha",
     "wof:parent_id":85673409,
     "wof:placetype":"county",

--- a/data/109/203/050/3/1092030503.geojson
+++ b/data/109/203/050/3/1092030503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101999,
-    "geom:area_square_m":1187334602.148913,
+    "geom:area_square_m":1187334130.388912,
     "geom:bbox":"100.659465,19.487276,101.049042,19.90473",
     "geom:latitude":19.711393,
     "geom:longitude":100.831595,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XA.XI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897743,
-    "wof:geomhash":"22446d5e42d28e86f38f87a64c872bd4",
+    "wof:geomhash":"7e433a43124ce8f7a9db087ffa02305d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030503,
-    "wof:lastmodified":1627522314,
+    "wof:lastmodified":1695886777,
     "wof:name":"Xianghon",
     "wof:parent_id":85673417,
     "wof:placetype":"county",

--- a/data/109/203/053/7/1092030537.geojson
+++ b/data/109/203/053/7/1092030537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074583,
-    "geom:area_square_m":874806843.184084,
+    "geom:area_square_m":874806878.244872,
     "geom:bbox":"101.052418,18.21657,101.403195,18.632233",
     "geom:latitude":18.453633,
     "geom:longitude":101.228121,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XA.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897744,
-    "wof:geomhash":"c2106d911e65e0e9cdca04c0025b76e8",
+    "wof:geomhash":"bdbb7484b159de5a16059aca9a8e3093",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030537,
-    "wof:lastmodified":1627522323,
+    "wof:lastmodified":1695886785,
     "wof:name":"Thongmixai",
     "wof:parent_id":85673417,
     "wof:placetype":"county",

--- a/data/109/203/058/5/1092030585.geojson
+++ b/data/109/203/058/5/1092030585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113945,
-    "geom:area_square_m":1351706539.742541,
+    "geom:area_square_m":1351706091.736322,
     "geom:bbox":"105.283494,16.230326,105.810304,16.57156",
     "geom:latitude":16.387974,
     "geom:longitude":105.545251,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.XO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897746,
-    "wof:geomhash":"4a06338c0a9cdaabc817dd3093361503",
+    "wof:geomhash":"e0340bd907bfd0863ca766da6bc50962",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030585,
-    "wof:lastmodified":1627522315,
+    "wof:lastmodified":1695886778,
     "wof:name":"Xonbouri",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/203/063/5/1092030635.geojson
+++ b/data/109/203/063/5/1092030635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.206564,
-    "geom:area_square_m":2398877057.679494,
+    "geom:area_square_m":2398876281.840118,
     "geom:bbox":"103.497034,19.793698,104.166158,20.344844",
     "geom:latitude":20.083929,
     "geom:longitude":103.823431,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.HO.HU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897747,
-    "wof:geomhash":"cf748c87b8c129ba30d5d734220f9867",
+    "wof:geomhash":"22d47c953b465f5fc84c7f1370cd0447",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030635,
-    "wof:lastmodified":1627522316,
+    "wof:lastmodified":1695886779,
     "wof:name":"Houamuang",
     "wof:parent_id":85673447,
     "wof:placetype":"county",

--- a/data/109/203/066/3/1092030663.geojson
+++ b/data/109/203/066/3/1092030663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107542,
-    "geom:area_square_m":1265739051.189907,
+    "geom:area_square_m":1265739424.351475,
     "geom:bbox":"101.109841,17.607697,101.573988,18.093495",
     "geom:latitude":17.85418,
     "geom:longitude":101.312893,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XA.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897749,
-    "wof:geomhash":"a2db56987ac4bb99671137d3c42ad4e2",
+    "wof:geomhash":"b4e2466faa9825f28cbc3a572da786fa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030663,
-    "wof:lastmodified":1627522316,
+    "wof:lastmodified":1695886779,
     "wof:name":"Kenthao",
     "wof:parent_id":85673417,
     "wof:placetype":"county",

--- a/data/109/203/070/7/1092030707.geojson
+++ b/data/109/203/070/7/1092030707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138036,
-    "geom:area_square_m":1596896801.827988,
+    "geom:area_square_m":1596896967.793046,
     "geom:bbox":"100.197372,20.478847,100.841797,20.8466",
     "geom:latitude":20.677087,
     "geom:longitude":100.529386,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BK.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897750,
-    "wof:geomhash":"e095d461bb0b9e9b5ac4094b9ff86c98",
+    "wof:geomhash":"3416e7450bec614b1ac85008315cd5c7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030707,
-    "wof:lastmodified":1627522318,
+    "wof:lastmodified":1695886781,
     "wof:name":"Meung",
     "wof:parent_id":85673409,
     "wof:placetype":"county",

--- a/data/109/203/075/3/1092030753.geojson
+++ b/data/109/203/075/3/1092030753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.374963,
-    "geom:area_square_m":4400493963.764515,
+    "geom:area_square_m":4400493677.860537,
     "geom:bbox":"104.543806,17.939884,105.259205,18.801476",
     "geom:latitude":18.35831,
     "geom:longitude":104.92151,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BL.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897752,
-    "wof:geomhash":"bfab835876022001a02e217cfd5b5bfa",
+    "wof:geomhash":"c847604b93fd24559560630b24b379aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030753,
-    "wof:lastmodified":1627522317,
+    "wof:lastmodified":1695886780,
     "wof:name":"Khamkeut",
     "wof:parent_id":85673463,
     "wof:placetype":"county",

--- a/data/109/203/079/1/1092030791.geojson
+++ b/data/109/203/079/1/1092030791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.372163,
-    "geom:area_square_m":4379775750.206015,
+    "geom:area_square_m":4379776204.681519,
     "geom:bbox":"104.778975,17.598179,105.762168,18.264766",
     "geom:latitude":17.872332,
     "geom:longitude":105.285302,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.KH.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897753,
-    "wof:geomhash":"ee42e2fc25f58db986662ad2269a0381",
+    "wof:geomhash":"982f3b0c3f933333d2261a1cbfa8265f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030791,
-    "wof:lastmodified":1627522318,
+    "wof:lastmodified":1695886781,
     "wof:name":"Nakay",
     "wof:parent_id":85673467,
     "wof:placetype":"county",

--- a/data/109/203/083/5/1092030835.geojson
+++ b/data/109/203/083/5/1092030835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.180032,
-    "geom:area_square_m":2114010945.663102,
+    "geom:area_square_m":2114010621.628034,
     "geom:bbox":"103.888169,17.886698,104.543205,18.560061",
     "geom:latitude":18.26113,
     "geom:longitude":104.206296,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BL.PD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897755,
-    "wof:geomhash":"abbb4a3655773e7279f43adc4e963d94",
+    "wof:geomhash":"27a67fe0569e00d36b448b0366621c70",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030835,
-    "wof:lastmodified":1627522320,
+    "wof:lastmodified":1695886782,
     "wof:name":"Pakkading",
     "wof:parent_id":85673463,
     "wof:placetype":"county",

--- a/data/109/203/087/9/1092030879.geojson
+++ b/data/109/203/087/9/1092030879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.226791,
-    "geom:area_square_m":2607703288.604061,
+    "geom:area_square_m":2607702998.263845,
     "geom:bbox":"102.103848,21.194386,102.675289,22.110943",
     "geom:latitude":21.581554,
     "geom:longitude":102.405029,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.PH.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897756,
-    "wof:geomhash":"2c1e27215ea6919ead8734f31fd49186",
+    "wof:geomhash":"c05bea543500c1303afe99e862db0e33",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030879,
-    "wof:lastmodified":1627522321,
+    "wof:lastmodified":1695886783,
     "wof:name":"Samphan",
     "wof:parent_id":85673459,
     "wof:placetype":"county",

--- a/data/109/203/092/5/1092030925.geojson
+++ b/data/109/203/092/5/1092030925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.118806,
-    "geom:area_square_m":1368975075.452548,
+    "geom:area_square_m":1368974940.261431,
     "geom:bbox":"100.846495,20.983156,101.28853,21.564628",
     "geom:latitude":21.271724,
     "geom:longitude":101.103627,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LM.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897758,
-    "wof:geomhash":"dadedd0b81d1200b54f65d80417ef12b",
+    "wof:geomhash":"402ececf45b64694548956a273e2ba81",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030925,
-    "wof:lastmodified":1627522322,
+    "wof:lastmodified":1695886784,
     "wof:name":"Sing",
     "wof:parent_id":85673413,
     "wof:placetype":"county",

--- a/data/109/203/095/9/1092030959.geojson
+++ b/data/109/203/095/9/1092030959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049848,
-    "geom:area_square_m":591457309.678695,
+    "geom:area_square_m":591457255.695724,
     "geom:bbox":"104.861404,16.171386,105.164563,16.503879",
     "geom:latitude":16.349301,
     "geom:longitude":105.017834,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.XP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897759,
-    "wof:geomhash":"2abde01a8a348129363ea2e8db2b060d",
+    "wof:geomhash":"fe1e142f50d7cb256036cfa395983db1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030959,
-    "wof:lastmodified":1627522324,
+    "wof:lastmodified":1695886785,
     "wof:name":"Xaiphouthong",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/203/099/1/1092030991.geojson
+++ b/data/109/203/099/1/1092030991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076392,
-    "geom:area_square_m":910940835.206646,
+    "geom:area_square_m":910941166.800408,
     "geom:bbox":"105.467445,15.159047,105.990488,15.457894",
     "geom:latitude":15.342497,
     "geom:longitude":105.738187,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.CH.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897761,
-    "wof:geomhash":"926956214f5117916f824021e608b0ca",
+    "wof:geomhash":"76ed29423e9b87c2c459ba9112935a18",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092030991,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886786,
     "wof:name":"Xanasomboun",
     "wof:parent_id":85673423,
     "wof:placetype":"county",

--- a/data/109/203/102/5/1092031025.geojson
+++ b/data/109/203/102/5/1092031025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061114,
-    "geom:area_square_m":723788837.061721,
+    "geom:area_square_m":723789062.16452,
     "geom:bbox":"105.169546,16.556085,105.515135,16.841963",
     "geom:latitude":16.705781,
     "geom:longitude":105.331457,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897762,
-    "wof:geomhash":"1e798876e4650c8d5dbff301a242c7ed",
+    "wof:geomhash":"50808fbaea5eabadaa05d673db6b6f8b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031025,
-    "wof:lastmodified":1627522314,
+    "wof:lastmodified":1695886777,
     "wof:name":"Atsaphangthong",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/109/203/105/5/1092031055.geojson
+++ b/data/109/203/105/5/1092031055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10386,
-    "geom:area_square_m":1193337673.470018,
+    "geom:area_square_m":1193337104.064553,
     "geom:bbox":"101.725728,21.426769,102.028582,21.944534",
     "geom:latitude":21.687946,
     "geom:longitude":101.87515,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.PH.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897764,
-    "wof:geomhash":"08fd38bd8ad8e091281678a65766e41e",
+    "wof:geomhash":"868c20f7ff815e668e724f4f8e05003f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031055,
-    "wof:lastmodified":1627522315,
+    "wof:lastmodified":1695886778,
     "wof:name":"Boun-Nua",
     "wof:parent_id":85673459,
     "wof:placetype":"county",

--- a/data/109/203/109/1/1092031091.geojson
+++ b/data/109/203/109/1/1092031091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086996,
-    "geom:area_square_m":1006119464.051192,
+    "geom:area_square_m":1006119659.230713,
     "geom:bbox":"103.657649,20.54895,104.097277,20.913256",
     "geom:latitude":20.724207,
     "geom:longitude":103.883473,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.HO.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897765,
-    "wof:geomhash":"27b389f566809e2cf126446cc2803171",
+    "wof:geomhash":"adf0a443772f23564ac57ca560099134",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031091,
-    "wof:lastmodified":1627522315,
+    "wof:lastmodified":1695886779,
     "wof:name":"Et",
     "wof:parent_id":85673447,
     "wof:placetype":"county",

--- a/data/109/203/111/7/1092031117.geojson
+++ b/data/109/203/111/7/1092031117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13379,
-    "geom:area_square_m":1577233259.227368,
+    "geom:area_square_m":1577233114.51937,
     "geom:bbox":"104.845796,17.389128,105.68493,17.695531",
     "geom:latitude":17.562124,
     "geom:longitude":105.261365,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.KH.NH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897767,
-    "wof:geomhash":"ca61c28513ecc995fc9588210aebb9f7",
+    "wof:geomhash":"ce28efe60a90d4c93a0336a0fec301d7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031117,
-    "wof:lastmodified":1627522315,
+    "wof:lastmodified":1695886779,
     "wof:name":"Gnommalat",
     "wof:parent_id":85673467,
     "wof:placetype":"county",

--- a/data/109/203/114/5/1092031145.geojson
+++ b/data/109/203/114/5/1092031145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117124,
-    "geom:area_square_m":1382278251.995744,
+    "geom:area_square_m":1382278266.253187,
     "geom:bbox":"104.988071,17.183614,105.679794,17.498857",
     "geom:latitude":17.362385,
     "geom:longitude":105.303403,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.KH.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897774,
-    "wof:geomhash":"9bb9320dadb70ee0294be22ace5bbb0c",
+    "wof:geomhash":"13c0f9620a26efa94083cb28cabafbf4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031145,
-    "wof:lastmodified":1627522318,
+    "wof:lastmodified":1695886781,
     "wof:name":"Mahaxai",
     "wof:parent_id":85673467,
     "wof:placetype":"county",

--- a/data/109/203/116/7/1092031167.geojson
+++ b/data/109/203/116/7/1092031167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.148728,
-    "geom:area_square_m":1723817758.286255,
+    "geom:area_square_m":1723817758.286511,
     "geom:bbox":"100.296906683,20.142834,101.009301554,20.5738439994",
     "geom:latitude":20.389773,
     "geom:longitude":100.630044,
@@ -107,9 +107,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BK.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897775,
-    "wof:geomhash":"bc27762efe0f787616683ff5759af8e0",
+    "wof:geomhash":"5e9d5ccc2c2e9b85b0cb4a499f958904",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092031167,
-    "wof:lastmodified":1566593277,
+    "wof:lastmodified":1695886702,
     "wof:name":"Houayxay",
     "wof:parent_id":85673409,
     "wof:placetype":"county",

--- a/data/109/203/120/7/1092031207.geojson
+++ b/data/109/203/120/7/1092031207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.140077,
-    "geom:area_square_m":1618051555.896281,
+    "geom:area_square_m":1618051610.916359,
     "geom:bbox":"101.423524,20.633904,101.998179,21.220436",
     "geom:latitude":20.90545,
     "geom:longitude":101.727658,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"LA.OU.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897777,
-    "wof:geomhash":"172c01994beb8a6a4c3f7a0fad0fc529",
+    "wof:geomhash":"deecb6c6478ee3161ae0978d0a50d9cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1092031207,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886782,
     "wof:name":"Namo",
     "wof:parent_id":85673453,
     "wof:placetype":"county",

--- a/data/109/203/124/3/1092031243.geojson
+++ b/data/109/203/124/3/1092031243.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.XI.NO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897778,
     "wof:geomhash":"8d512920de7459f7fcfb7855d12fb05e",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092031243,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886782,
     "wof:name":"Nonghet",
     "wof:parent_id":85673441,
     "wof:placetype":"county",

--- a/data/109/203/129/3/1092031293.geojson
+++ b/data/109/203/129/3/1092031293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.229366,
-    "geom:area_square_m":2743416226.872561,
+    "geom:area_square_m":2743416519.186723,
     "geom:bbox":"105.84502,14.336964,106.355691,15.080221",
     "geom:latitude":14.691286,
     "geom:longitude":106.066316,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.CH.PT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897781,
-    "wof:geomhash":"31ea29421e249bea8ed4a79664b5f3a1",
+    "wof:geomhash":"414649ce3fc7970807a1d9bd237681dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031293,
-    "wof:lastmodified":1627522320,
+    "wof:lastmodified":1695886782,
     "wof:name":"Pathoumphon",
     "wof:parent_id":85673423,
     "wof:placetype":"county",

--- a/data/109/203/134/9/1092031349.geojson
+++ b/data/109/203/134/9/1092031349.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"LA.XI.PX"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897783,
     "wof:geomhash":"b0ae15682342ff51883d25a1771c5ac5",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092031349,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886783,
     "wof:name":"Phaxai",
     "wof:parent_id":85673441,
     "wof:placetype":"county",

--- a/data/109/203/137/5/1092031375.geojson
+++ b/data/109/203/137/5/1092031375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.253841,
-    "geom:area_square_m":2969959860.470575,
+    "geom:area_square_m":2969959963.088153,
     "geom:bbox":"101.223803,18.524465,101.729726,19.231927",
     "geom:latitude":18.876897,
     "geom:longitude":101.467779,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XA.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897784,
-    "wof:geomhash":"3adc807b359584f9aa97534e721e1ffa",
+    "wof:geomhash":"8d4b8ed59b24a8dd1708b9c6bd36d19b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031375,
-    "wof:lastmodified":1627522320,
+    "wof:lastmodified":1695886783,
     "wof:name":"Phiang",
     "wof:parent_id":85673417,
     "wof:placetype":"county",

--- a/data/109/203/150/1/1092031501.geojson
+++ b/data/109/203/150/1/1092031501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.141152,
-    "geom:area_square_m":1656045514.7202,
+    "geom:area_square_m":1656045327.642423,
     "geom:bbox":"102.810962,18.187214,103.492633,18.643847",
     "geom:latitude":18.409225,
     "geom:longitude":103.132026,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.BL.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897788,
-    "wof:geomhash":"1d1abbe36a513c7fb0a42941f6411f47",
+    "wof:geomhash":"cdd861916d493d62f1c76c96025c172f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031501,
-    "wof:lastmodified":1627522323,
+    "wof:lastmodified":1695886785,
     "wof:name":"Thaphabat",
     "wof:parent_id":85673463,
     "wof:placetype":"county",

--- a/data/109/203/153/9/1092031539.geojson
+++ b/data/109/203/153/9/1092031539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045649,
-    "geom:area_square_m":544100910.697216,
+    "geom:area_square_m":544101224.62211,
     "geom:bbox":"106.301509,15.314354,106.630943,15.548836",
     "geom:latitude":15.435986,
     "geom:longitude":106.483321,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.XE.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897790,
-    "wof:geomhash":"493b90739f7166f5a3fe6765e193c60c",
+    "wof:geomhash":"3557ec7ecbbec9650ae61e223c96c6ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031539,
-    "wof:lastmodified":1627522323,
+    "wof:lastmodified":1695886785,
     "wof:name":"Thateng",
     "wof:parent_id":85673473,
     "wof:placetype":"county",

--- a/data/109/203/158/3/1092031583.geojson
+++ b/data/109/203/158/3/1092031583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.285261,
-    "geom:area_square_m":3304187526.710698,
+    "geom:area_square_m":3304188363.826039,
     "geom:bbox":"102.770976,20.022568,103.38776,20.984808",
     "geom:latitude":20.487066,
     "geom:longitude":103.038271,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.LP.VI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897791,
-    "wof:geomhash":"eafb6c07d74568afb9471e4c299ceaa6",
+    "wof:geomhash":"d68dd524f971e117e5a24ab936d22dc0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031583,
-    "wof:lastmodified":1627522323,
+    "wof:lastmodified":1695886785,
     "wof:name":"Viangkham",
     "wof:parent_id":85673451,
     "wof:placetype":"county",

--- a/data/109/203/162/1/1092031621.geojson
+++ b/data/109/203/162/1/1092031621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139538,
-    "geom:area_square_m":1617728761.949651,
+    "geom:area_square_m":1617728846.544385,
     "geom:bbox":"104.125755,20.143634,104.713545,20.634306",
     "geom:latitude":20.34925,
     "geom:longitude":104.400271,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"LA.HO.VX"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897793,
-    "wof:geomhash":"6563cb95344e1eef33b28326d3f60c88",
+    "wof:geomhash":"a00e711c6440b142c470cfad473e1454",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092031621,
-    "wof:lastmodified":1627522323,
+    "wof:lastmodified":1695886785,
     "wof:name":"Viangxai",
     "wof:parent_id":85673447,
     "wof:placetype":"county",

--- a/data/110/841/184/9/1108411849.geojson
+++ b/data/110/841/184/9/1108411849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129676,
-    "geom:area_square_m":1554814179.289492,
+    "geom:area_square_m":1554814118.222735,
     "geom:bbox":"105.774864,13.90972,106.187886,14.492897",
     "geom:latitude":14.149167,
     "geom:longitude":105.957214,
@@ -99,9 +99,10 @@
         "hasc:id":"LA.CH.KH",
         "qs_pg:id":1210503
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1459008883,
-    "wof:geomhash":"8ab7fdc4fd91b1b123a07e974e5ba0c9",
+    "wof:geomhash":"f01a08100c3c1bffa940a47884fb0bbc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108411849,
-    "wof:lastmodified":1627522317,
+    "wof:lastmodified":1695886780,
     "wof:name":"Khong",
     "wof:parent_id":85673423,
     "wof:placetype":"county",

--- a/data/117/561/289/9/1175612899.geojson
+++ b/data/117/561/289/9/1175612899.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"LA.AT.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
     "wof:created":1473897785,
     "wof:geomhash":"aa333cf43d2c9d446656dba54d4938bf",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1175612899,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886783,
     "wof:name":"Sanamxai",
     "wof:parent_id":85673469,
     "wof:placetype":"county",

--- a/data/151/185/479/1/1511854791.geojson
+++ b/data/151/185/479/1/1511854791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144088,
-    "geom:area_square_m":1577233259.227368,
+    "geom:area_square_m":1709264778.600264,
     "geom:bbox":"106.223063,16.143052,106.799749,16.585699",
     "geom:latitude":16.390201,
     "geom:longitude":106.503564,
@@ -49,8 +49,9 @@
     "wof:concordances":{
         "hasc:id":"LA.SV.NO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LA",
-    "wof:geomhash":"fa4d045113384d6c1dbec112fdc9656b",
+    "wof:geomhash":"e49298087801966cd5eaa60ac56fd341",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1511854791,
-    "wof:lastmodified":1627522319,
+    "wof:lastmodified":1695886782,
     "wof:name":"Nong",
     "wof:parent_id":85673429,
     "wof:placetype":"county",

--- a/data/856/322/41/85632241.geojson
+++ b/data/856/322/41/85632241.geojson
@@ -1182,6 +1182,7 @@
         "hasc:id":"LA",
         "icao:code":"RDPL",
         "ioc:id":"LAO",
+        "iso:code":"LA",
         "itu:id":"LAO",
         "m49:code":"418",
         "marc:id":"ls",
@@ -1195,6 +1196,7 @@
         "wk:page":"Laos",
         "wmo:id":"LA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:country_alpha3":"LAO",
     "wof:geom_alt":[
@@ -1216,7 +1218,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1694639510,
+    "wof:lastmodified":1695881165,
     "wof:name":"Laos",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/734/09/85673409.geojson
+++ b/data/856/734/09/85673409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.600184,
-    "geom:area_square_m":6957642663.069195,
+    "geom:area_square_m":6957642062.666597,
     "geom:bbox":"100.083872,19.770885,101.254457,20.8466",
     "geom:latitude":20.360714,
     "geom:longitude":100.638385,
@@ -299,16 +299,18 @@
         "gn:id":1904616,
         "gp:id":20070156,
         "hasc:id":"LA.BK",
+        "iso:code":"LA-BK",
         "iso:id":"LA-BK",
         "qs_pg:id":890355,
         "wd:id":"Q334884",
         "wk:page":"Bokeo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1ac5224cfa5fc7facbafb898af6cd305",
+    "wof:geomhash":"b0d3ab4ebafb1fc26040b638ce7c950f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938494,
+    "wof:lastmodified":1695884803,
     "wof:name":"Bokeo",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/13/85673413.geojson
+++ b/data/856/734/13/85673413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.830214,
-    "geom:area_square_m":9590580440.765633,
+    "geom:area_square_m":9590581242.94059,
     "geom:bbox":"100.509212,20.304753,101.773536,21.564628",
     "geom:latitude":20.894125,
     "geom:longitude":101.14116,
@@ -314,16 +314,18 @@
         "gn:id":1655561,
         "gp:id":2346003,
         "hasc:id":"LA.LM",
+        "iso:code":"LA-LM",
         "iso:id":"LA-LM",
         "qs_pg:id":1135128,
         "unlc:id":"LA-LM",
         "wd:id":"Q948691"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5e62f3611564804983bff06cea8630cc",
+    "wof:geomhash":"b2034e84036b3fe319e1af5f5c5aa5a4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938496,
+    "wof:lastmodified":1695884803,
     "wof:name":"Louang Namtha",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/17/85673417.geojson
+++ b/data/856/734/17/85673417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.327195,
-    "geom:area_square_m":15520498754.321367,
+    "geom:area_square_m":15520498399.103348,
     "geom:bbox":"100.403787,17.466021,101.893994,19.936088",
     "geom:latitude":18.949895,
     "geom:longitude":101.343015,
@@ -312,16 +312,18 @@
         "gn:id":1652210,
         "gp:id":2346010,
         "hasc:id":"LA.XA",
+        "iso:code":"LA-XA",
         "iso:id":"LA-XA",
         "qs_pg:id":1046867,
         "wd:id":"Q465929",
         "wk:page":"Sainyabuli Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"303bdd070faabf57b38d710f8f87a347",
+    "wof:geomhash":"8981b281371026b3038e39c4600a2c18",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938493,
+    "wof:lastmodified":1695884803,
     "wof:name":"Xaignabouri",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/23/85673423.geojson
+++ b/data/856/734/23/85673423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.255918,
-    "geom:area_square_m":15015744953.468338,
+    "geom:area_square_m":15015744812.498365,
     "geom:bbox":"105.205587,13.90972,106.827767,15.470085",
     "geom:latitude":14.775882,
     "geom:longitude":105.9608,
@@ -321,16 +321,18 @@
         "gn:id":1657818,
         "gp:id":20070160,
         "hasc:id":"LA.CH",
+        "iso:code":"LA-CH",
         "iso:id":"LA-CH",
         "qs_pg:id":348939,
         "wd:id":"Q334888",
         "wk:page":"Champasak Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e09f1571913bd63e97327f67f03d296b",
+    "wof:geomhash":"e1324fe630fbb643fd8454f6be9745be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -345,7 +347,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938495,
+    "wof:lastmodified":1695884803,
     "wof:name":"Champasak",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/27/85673427.geojson
+++ b/data/856/734/27/85673427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.855756,
-    "geom:area_square_m":10179219979.793169,
+    "geom:area_square_m":10179220812.806177,
     "geom:bbox":"105.342227,15.283702,107.156925,16.55023",
     "geom:latitude":15.849126,
     "geom:longitude":106.271634,
@@ -306,16 +306,18 @@
         "gn:id":1653333,
         "gp:id":20070157,
         "hasc:id":"LA.SL",
+        "iso:code":"LA-SL",
         "iso:id":"LA-SL",
         "qs_pg:id":1287640,
         "wd:id":"Q302656",
         "wk:page":"Salavan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"37fb316a96338e99ac319b4bc4be1667",
+    "wof:geomhash":"58eb7af2f0e27bb397b7cb5c85cff9db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938492,
+    "wof:lastmodified":1695884803,
     "wof:name":"Saravan",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/29/85673429.geojson
+++ b/data/856/734/29/85673429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.811217,
-    "geom:area_square_m":21467572096.662025,
+    "geom:area_square_m":21467571679.46508,
     "geom:bbox":"104.733283,15.876764,106.799749,17.121918",
     "geom:latitude":16.553256,
     "geom:longitude":105.706101,
@@ -307,17 +307,19 @@
         "gn:id":1653315,
         "gp:id":2346008,
         "hasc:id":"LA.SV",
+        "iso:code":"LA-SV",
         "iso:id":"LA-SV",
         "qs_pg:id":894915,
         "unlc:id":"LA-SV",
         "wd:id":"Q465940",
         "wk:page":"Savannakhet Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0edd4395a553d24c160793345e6a7fdf",
+    "wof:geomhash":"6d7e7984fc0ffb8cf19e440fe7555608",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -332,7 +334,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938492,
+    "wof:lastmodified":1695884519,
     "wof:name":"Savannakh\u00e9t",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/33/85673433.geojson
+++ b/data/856/734/33/85673433.geojson
@@ -246,10 +246,12 @@
         "gn:id":1904618,
         "gp:id":20070162,
         "hasc:id":"LA.VT",
+        "iso:code":"LA-VT",
         "qs_pg:id":1154061,
         "wd:id":"Q390377",
         "wk:page":"Vientiane Prefecture"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -269,7 +271,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1694493174,
+    "wof:lastmodified":1695884519,
     "wof:name":"Vientiane (prefecture)",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/37/85673437.geojson
+++ b/data/856/734/37/85673437.geojson
@@ -236,10 +236,12 @@
         "gn:id":1904618,
         "gp:id":20070164,
         "hasc:id":"LA.VI",
+        "iso:code":"LA-VI",
         "qs_pg:id":348940,
         "wd:id":"Q390377",
         "wk:page":"Vientiane Prefecture"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -259,7 +261,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1694493256,
+    "wof:lastmodified":1695884804,
     "wof:name":"Vientiane",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/41/85673441.geojson
+++ b/data/856/734/41/85673441.geojson
@@ -308,10 +308,12 @@
         "gn:id":1652077,
         "gp:id":2346011,
         "hasc:id":"LA.XI",
+        "iso:code":"LA-XI",
         "qs_pg:id":1046868,
         "wd:id":"Q465947",
         "wk:page":"Xiangkhouang Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1694493174,
+    "wof:lastmodified":1695884520,
     "wof:name":"Xiangkhoang",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/47/85673447.geojson
+++ b/data/856/734/47/85673447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.514192,
-    "geom:area_square_m":17562102477.817406,
+    "geom:area_square_m":17562101736.169487,
     "geom:bbox":"103.111778,19.609125,104.993292,20.978451",
     "geom:latitude":20.282405,
     "geom:longitude":104.015959,
@@ -336,17 +336,19 @@
         "gn:id":1657114,
         "gp:id":2346001,
         "hasc:id":"LA.HO",
+        "iso:code":"LA-HO",
         "iso:id":"LA-HO",
         "qs_pg:id":423790,
         "unlc:id":"LA-HO",
         "wd:id":"Q502997",
         "wk:page":"Houaphanh Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a4b44770cf94b6397098a71023f73d64",
+    "wof:geomhash":"2266f708caa19d1c3b8eff495b822ad3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -361,7 +363,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938496,
+    "wof:lastmodified":1695884520,
     "wof:name":"Houaphan",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/51/85673451.geojson
+++ b/data/856/734/51/85673451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.712723,
-    "geom:area_square_m":19884688161.114811,
+    "geom:area_square_m":19884689066.50037,
     "geom:bbox":"101.724884,19.04826,103.38776,21.134255",
     "geom:latitude":20.122969,
     "geom:longitude":102.546712,
@@ -293,16 +293,18 @@
         "gn:id":1655558,
         "gp:id":2346004,
         "hasc:id":"LA.LP",
+        "iso:code":"LA-LP",
         "iso:id":"LA-LP",
         "qs_pg:id":894913,
         "wd:id":"Q747881",
         "wk:page":"Luang Prabang Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0640a19b48c91d8d54d174cc4ff4d7dc",
+    "wof:geomhash":"2fd69efa5f039603954ccfdf8bb1cb4e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -317,7 +319,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938491,
+    "wof:lastmodified":1695884519,
     "wof:name":"Luangphrabang",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/53/85673453.geojson
+++ b/data/856/734/53/85673453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.018591,
-    "geom:area_square_m":11802908856.490669,
+    "geom:area_square_m":11802909578.349791,
     "geom:bbox":"100.731161,19.81696,102.363799,21.220436",
     "geom:latitude":20.426002,
     "geom:longitude":101.724243,
@@ -303,16 +303,18 @@
         "gn:id":1654491,
         "gp:id":2346005,
         "hasc:id":"LA.OU",
+        "iso:code":"LA-OU",
         "iso:id":"LA-OU",
         "qs_pg:id":894914,
         "wd:id":"Q465961",
         "wk:page":"Oudomxay Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8a250aa663899aa96833e09e2b28fcf5",
+    "wof:geomhash":"6d374d2c0caa827c758c7f2c6e0cb408",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938494,
+    "wof:lastmodified":1695884520,
     "wof:name":"Oud\u00f4mxai",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/59/85673459.geojson
+++ b/data/856/734/59/85673459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.354139,
-    "geom:area_square_m":15563066108.027884,
+    "geom:area_square_m":15563066117.784985,
     "geom:bbox":"101.537844,20.830312,102.993228,22.502872",
     "geom:latitude":21.645739,
     "geom:longitude":102.240636,
@@ -304,16 +304,18 @@
         "gn:id":1653893,
         "gp:id":2346006,
         "hasc:id":"LA.PH",
+        "iso:code":"LA-PH",
         "iso:id":"LA-PH",
         "qs_pg:id":1030864,
         "wd:id":"Q334868",
         "wk:page":"Phongsaly Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5a08fec95d84e03c98ebb59a8fd7d49c",
+    "wof:geomhash":"83f739560fb21e5b65805290fe5015ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938490,
+    "wof:lastmodified":1695884519,
     "wof:name":"Ph\u00f4ngsali",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/63/85673463.geojson
+++ b/data/856/734/63/85673463.geojson
@@ -291,10 +291,12 @@
         "gn:id":1904617,
         "gp:id":20070163,
         "hasc:id":"LA.BL",
+        "iso:code":"LA-BL",
         "qs_pg:id":202012,
         "wd:id":"Q2403514",
         "wk:page":"Bolikhamsai Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
@@ -314,7 +316,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1694493174,
+    "wof:lastmodified":1695884520,
     "wof:name":"Borikhamxai",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/67/85673467.geojson
+++ b/data/856/734/67/85673467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.426769,
-    "geom:area_square_m":16818745437.993938,
+    "geom:area_square_m":16818745786.707184,
     "geom:bbox":"104.264122,16.903298,106.431929,18.264766",
     "geom:latitude":17.572553,
     "geom:longitude":105.257733,
@@ -305,17 +305,19 @@
         "gn:id":1656538,
         "gp:id":20070161,
         "hasc:id":"LA.KH",
+        "iso:code":"LA-KH",
         "iso:id":"LA-KH",
         "qs_pg:id":1149779,
         "unlc:id":"LA-KH",
         "wd:id":"Q506641",
         "wk:page":"Khammouane Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"355da8e3773fdc690c25f898cc225f0a",
+    "wof:geomhash":"95e1c4f3d40d5383e648b9ef00c54c69",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938492,
+    "wof:lastmodified":1695884803,
     "wof:name":"Khammouan",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/69/85673469.geojson
+++ b/data/856/734/69/85673469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.800841,
-    "geom:area_square_m":9573936181.344082,
+    "geom:area_square_m":9573935670.394714,
     "geom:bbox":"106.174621,14.292068,107.599227,15.291166",
     "geom:latitude":14.800395,
     "geom:longitude":106.947563,
@@ -312,16 +312,18 @@
         "gn:id":1665045,
         "gp:id":20070159,
         "hasc:id":"LA.AT",
+        "iso:code":"LA-AT",
         "iso:id":"LA-AT",
         "qs_pg:id":348938,
         "wd:id":"Q503004",
         "wk:page":"Attapeu Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7d011f060db8e7247aa57dce92187437",
+    "wof:geomhash":"bbfdbbdc87a89f27ab7d690e53410339",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938491,
+    "wof:lastmodified":1695884519,
     "wof:name":"Attapeu",
     "wof:parent_id":85632241,
     "wof:placetype":"region",

--- a/data/856/734/73/85673473.geojson
+++ b/data/856/734/73/85673473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.706452,
-    "geom:area_square_m":8414189705.196557,
+    "geom:area_square_m":8414189664.389752,
     "geom:bbox":"106.301509,15.028438,107.69483,16.183214",
     "geom:latitude":15.584178,
     "geom:longitude":107.046117,
@@ -302,16 +302,18 @@
         "gn:id":1904615,
         "gp:id":20070158,
         "hasc:id":"LA.XE",
+        "iso:code":"LA-XE",
         "iso:id":"LA-XE",
         "qs_pg:id":1287641,
         "wd:id":"Q585707",
         "wk:page":"Sekong Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd9319570d88d36eadf86589fcb26419",
+    "wof:geomhash":"957486aa9d93537e708074f7ddda4ee2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "lao"
     ],
-    "wof:lastmodified":1690938493,
+    "wof:lastmodified":1695884520,
     "wof:name":"X\u00e9kong",
     "wof:parent_id":85632241,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.